### PR TITLE
Harden & isolate the Claude Code invocation; live streaming (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ claude:
                  # your interactive default. Defaults to "sonnet" if unset.
 ```
 
+> **Note:** config-file *loading* is not wired up yet ([#5](https://github.com/aaronsb/yay-friend/issues/5)) — the tool currently runs on the built-in defaults above (model `sonnet`, default prompt). Editing `config.yaml` (including `claude.model` and the prompt template) won't take effect until that lands. Everything documented here reflects those defaults.
+
 ## 🧪 Development & Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A security-focused wrapper around `yay` that uses AI to analyze PKGBUILD files f
 
 - 🌪️ **Security Entropy Analysis** - Multi-factor risk assessment using AI
 - 🤖 **Claude Code Powered** - Runs your local Claude Code headless; no API key required (Qwen/Copilot/Goose providers are stubbed for the future — see [#1](https://github.com/aaronsb/yay-friend/issues/1))
-- 🔒 **Locked-down analysis** - Isolated Claude call with all tools denied, so untrusted PKGBUILDs can't execute anything
+- 🔒 **Locked-down analysis** - Isolated Claude call with built-in tools denied (defense-in-depth), so untrusted PKGBUILDs are read, not executed
 - 📊 **Comprehensive Analysis** - Source compilation, multiple origins, maintainer trust
 - ⚡ **Intelligent Caching** - Commit-hash based analysis caching for performance
 - 📡 **Malicious Package Reporting** - Automated threat intelligence sharing
@@ -73,9 +73,10 @@ and reads back the analysis. This has a few important consequences:
   [headless/programmatic mode](https://code.claude.com/docs/en/headless), the same
   mechanism the Claude Agent SDK is built on.
 - **Analysis runs locked down.** The Claude call is isolated: your MCP servers are
-  disabled and *all* built-in tools (Bash, file access, web) are denied, so an
-  untrusted PKGBUILD can be read and classified but can never cause Claude to
-  execute anything on your machine.
+  disabled and the known built-in tools (Bash, file access, web) are denied, so an
+  untrusted PKGBUILD is read and classified rather than executed. This is
+  defense-in-depth (an enumerated deny-list plus headless permission checks), not
+  a hard sandbox — see the `deniedTools` note in `internal/providers/claude.go`.
 
 > **Prerequisite:** Install and sign in to [Claude Code](https://claude.com/claude-code)
 > first (`claude` must be on your `PATH`). Verify with `yay-friend provider test claude`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A security-focused wrapper around `yay` that uses AI to analyze PKGBUILD files f
 ## ✨ Features
 
 - 🌪️ **Security Entropy Analysis** - Multi-factor risk assessment using AI
-- 🤖 **Multiple AI Providers** - Claude Code, Qwen, Copilot, Goose support
+- 🤖 **Claude Code Powered** - Runs your local Claude Code headless; no API key required (Qwen/Copilot/Goose providers are stubbed for the future — see [#1](https://github.com/aaronsb/yay-friend/issues/1))
+- 🔒 **Locked-down analysis** - Isolated Claude call with all tools denied, so untrusted PKGBUILDs can't execute anything
 - 📊 **Comprehensive Analysis** - Source compilation, multiple origins, maintainer trust
 - ⚡ **Intelligent Caching** - Commit-hash based analysis caching for performance
 - 📡 **Malicious Package Reporting** - Automated threat intelligence sharing
@@ -49,6 +50,35 @@ cd yay-friend
 go build -o yay-friend ./cmd/yay-friend
 ./install.sh --user --build
 ```
+
+## 🔑 Authentication & Cost
+
+`yay-friend` does **not** talk to any AI API directly. For each package it shells
+out to your **locally installed Claude Code** in headless mode (`claude --print`)
+and reads back the analysis. This has a few important consequences:
+
+- **It uses your own Claude authentication.** Whatever `claude` is already logged
+  into is what gets used — a **Claude Pro/Max subscription** *or* an
+  **`ANTHROPIC_API_KEY`**. No API key is required if you're signed in with a
+  subscription.
+- **It spends your own Claude usage.** Each fresh analysis is one Claude request
+  billed to *your* account (results are cached by AUR commit hash, so re-installs
+  and unchanged packages cost nothing). On a subscription, programmatic calls draw
+  from your plan's usage; if you want fully predictable, metered billing, set an
+  `ANTHROPIC_API_KEY` and Claude Code will use that instead.
+- **It never touches your credentials.** `yay-friend` only runs the official
+  `claude` binary and pipes a prompt to it over stdin. It does not read, extract,
+  store, or forward your subscription token or API key — Claude Code manages its
+  own auth internally. This is the officially supported
+  [headless/programmatic mode](https://code.claude.com/docs/en/headless), the same
+  mechanism the Claude Agent SDK is built on.
+- **Analysis runs locked down.** The Claude call is isolated: your MCP servers are
+  disabled and *all* built-in tools (Bash, file access, web) are denied, so an
+  untrusted PKGBUILD can be read and classified but can never cause Claude to
+  execute anything on your machine.
+
+> **Prerequisite:** Install and sign in to [Claude Code](https://claude.com/claude-code)
+> first (`claude` must be on your `PATH`). Verify with `yay-friend provider test claude`.
 
 ## 📋 Usage
 
@@ -105,7 +135,7 @@ yay-friend cache clear -y
 
 #### Cache Benefits
 - **⚡ 95%+ faster** for previously analyzed packages (no AI call needed)
-- **💰 Cost reduction** - Dramatically reduces AI provider API costs
+- **💰 Cost reduction** - Unchanged packages cost nothing; no repeat Claude usage
 - **🔄 Consistency** - Identical analysis results for same package version
 - **📱 Offline capability** - Re-analyze previously seen packages offline
 
@@ -269,10 +299,14 @@ security_thresholds:
 ```yaml
 default_provider: claude
 providers:
-  claude: ""     # Uses system claude command
-  qwen: ""       # Configuration path
-  copilot: ""    # Configuration path  
-  goose: ""      # Configuration path
+  claude: ""     # Uses your local `claude` command (the only working provider today)
+  qwen: ""       # Stub — not yet implemented (see issue #1)
+  copilot: ""    # Stub — not yet implemented
+  goose: ""      # Stub — not yet implemented
+claude:
+  model: sonnet  # Model alias passed to `claude --model` (e.g. sonnet, opus).
+                 # Pinned so analysis is reproducible instead of drifting with
+                 # your interactive default. Defaults to "sonnet" if unset.
 ```
 
 ## 🧪 Development & Testing

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/aaronsb/yay-friend
 
-go 1.21
+go 1.23
 
 require (
+	github.com/gookit/color v1.5.4
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1
@@ -10,7 +11,6 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/gookit/color v1.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,11 @@ import (
 	"github.com/aaronsb/yay-friend/internal/types"
 )
 
+// DefaultClaudeModel is the model alias passed to `claude --model` when the
+// user hasn't configured one. "sonnet" resolves to the latest Sonnet: a strong,
+// cost-effective choice for structured PKGBUILD security classification.
+const DefaultClaudeModel = "sonnet"
+
 // getConfigDir returns the XDG-compliant config directory
 func getConfigDir() string {
 	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
@@ -78,6 +83,11 @@ func Load() (*types.Config, error) {
 		}{
 			Path:  "yay",
 			Flags: []string{},
+		},
+		Claude: struct {
+			Model string `yaml:"model"`
+		}{
+			Model: DefaultClaudeModel,
 		},
 	}
 
@@ -149,6 +159,11 @@ func InitializeConfig() error {
 		}{
 			Path:  "yay",
 			Flags: []string{},
+		},
+		Claude: struct {
+			Model string `yaml:"model"`
+		}{
+			Model: DefaultClaudeModel,
 		},
 	}
 

--- a/internal/providers/claude.go
+++ b/internal/providers/claude.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -9,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aaronsb/yay-friend/internal/config"
@@ -138,64 +140,16 @@ func (c *ClaudeProvider) AnalyzePKGBUILDWithOptions(ctx context.Context, pkgInfo
 		_ = os.WriteFile(filepath.Join(claudeWorkDir, "last-prompt.txt"), []byte(prompt), 0600)
 	}
 
-	args := c.buildClaudeArgs()
-
-	var output []byte
-	var stderr bytes.Buffer
+	// On an interactive terminal, stream the analysis so the user gets live
+	// progress. When output is piped/redirected or a caller asked for no spinner
+	// (automation, CI), fall back to a single quiet one-shot call.
+	var resultText string
 	var err error
-
-	runClaude := func() {
-		cmd := exec.CommandContext(ctx, c.claudePath, args...)
-		cmd.Dir = claudeWorkDir // neutral working directory; see above
-		cmd.Stdin = strings.NewReader(prompt)
-		cmd.Stderr = &stderr
-		output, err = cmd.Output()
-	}
-
-	// Only animate the spinner on an interactive terminal; when output is piped
-	// or redirected (automation, CI), the \r-based spinner just spams lines.
 	if noSpinner || !isTerminal(os.Stdout) {
-		fmt.Printf("Analyzing with Claude...\n")
-		runClaude()
-		fmt.Printf("Analysis complete.\n")
+		resultText, err = c.runClaudeOneShot(ctx, prompt, claudeWorkDir)
 	} else {
-		fmt.Printf("Analyzing with Claude... ")
-
-		// Start spinner in a goroutine
-		done := make(chan bool)
-		go func() {
-			spinner := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-			i := 0
-			for {
-				select {
-				case <-done:
-					fmt.Printf("\r")
-					return
-				default:
-					fmt.Printf("\rAnalyzing with Claude... %s", spinner[i%len(spinner)])
-					i++
-					time.Sleep(100 * time.Millisecond)
-				}
-			}
-		}()
-
-		runClaude()
-
-		// Stop spinner and clear line
-		done <- true
-		time.Sleep(10 * time.Millisecond) // Give spinner time to clear
-		fmt.Printf("\rAnalyzing with Claude... Complete!\n")
+		resultText, err = c.runClaudeStreaming(ctx, prompt, claudeWorkDir)
 	}
-
-	if err != nil {
-		if stderr.Len() > 0 {
-			return nil, fmt.Errorf("claude analysis failed: %w: %s", err, strings.TrimSpace(stderr.String()))
-		}
-		return nil, fmt.Errorf("claude analysis failed: %w", err)
-	}
-
-	// Unwrap the structured JSON envelope to the model's text result.
-	resultText, err := extractClaudeResult(output)
 	if err != nil {
 		return nil, err
 	}
@@ -209,9 +163,7 @@ func (c *ClaudeProvider) AnalyzePKGBUILDWithOptions(ctx context.Context, pkgInfo
 	return analysis, nil
 }
 
-// buildClaudeArgs assembles the flags for a hardened, isolated headless call.
-// The invocation is deliberately minimal and locked down:
-//   - --print / --output-format json: non-interactive, structured envelope
+// baseClaudeArgs holds the hardened, isolated flags common to every invocation:
 //   - --model: pinned so analysis is reproducible rather than drifting with the
 //     user's interactive default
 //   - --strict-mcp-config + empty --mcp-config: ignore the user's MCP servers so
@@ -221,15 +173,126 @@ func (c *ClaudeProvider) AnalyzePKGBUILDWithOptions(ctx context.Context, pkgInfo
 // Authentication is intentionally left untouched: this inherits whatever the
 // local `claude` is logged into (subscription OAuth or ANTHROPIC_API_KEY).
 // yay-friend never reads, extracts, or forwards credentials.
-func (c *ClaudeProvider) buildClaudeArgs() []string {
+func (c *ClaudeProvider) baseClaudeArgs() []string {
 	return []string{
-		"--print",
-		"--output-format", "json",
 		"--model", c.getModel(),
 		"--strict-mcp-config",
 		"--mcp-config", `{"mcpServers":{}}`,
 		"--disallowedTools", strings.Join(deniedTools, ","),
 	}
+}
+
+// runClaudeOneShot runs a single non-interactive analysis and returns the model's
+// text result, unwrapped from the `--output-format json` envelope.
+func (c *ClaudeProvider) runClaudeOneShot(ctx context.Context, prompt, workDir string) (string, error) {
+	args := append([]string{"--print", "--output-format", "json"}, c.baseClaudeArgs()...)
+
+	fmt.Println("Analyzing with Claude...")
+	cmd := exec.CommandContext(ctx, c.claudePath, args...)
+	cmd.Dir = workDir
+	cmd.Stdin = strings.NewReader(prompt)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	fmt.Println("Analysis complete.")
+
+	if err != nil {
+		if stderr.Len() > 0 {
+			return "", fmt.Errorf("claude analysis failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+		}
+		return "", fmt.Errorf("claude analysis failed: %w", err)
+	}
+	return extractClaudeResult(output)
+}
+
+// runClaudeStreaming runs the analysis with `--output-format stream-json` and
+// renders a live progress line (elapsed time + phase) as newline-delimited JSON
+// events arrive, while capturing the final result event for parsing. stdout and
+// stderr are handled on separate pipes so a chatty stderr can't deadlock reads.
+func (c *ClaudeProvider) runClaudeStreaming(ctx context.Context, prompt, workDir string) (string, error) {
+	args := append([]string{"--print", "--output-format", "stream-json", "--verbose"}, c.baseClaudeArgs()...)
+
+	cmd := exec.CommandContext(ctx, c.claudePath, args...)
+	cmd.Dir = workDir
+	cmd.Stdin = strings.NewReader(prompt)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("failed to open claude output: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("failed to start claude: %w", err)
+	}
+
+	start := time.Now()
+	var mu sync.Mutex
+	phase := "starting"
+
+	// Progress ticker: repaint the elapsed/phase line a few times a second.
+	doneTick := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-doneTick:
+				return
+			case <-ticker.C:
+				mu.Lock()
+				p := phase
+				mu.Unlock()
+				fmt.Printf("\r\033[KAnalyzing with Claude (%ds, %s)…", int(time.Since(start).Seconds()), p)
+			}
+		}
+	}()
+
+	// Read events as they arrive. Use a Reader (not Scanner) so a large result
+	// line can't blow past a fixed token limit.
+	var resultEvent *claudeEvent
+	reader := bufio.NewReader(stdout)
+	for {
+		line, rerr := reader.ReadString('\n')
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			var ev claudeEvent
+			if json.Unmarshal([]byte(trimmed), &ev) == nil {
+				switch ev.Type {
+				case "assistant":
+					mu.Lock()
+					phase = "receiving"
+					mu.Unlock()
+				case "result":
+					e := ev
+					resultEvent = &e
+				}
+			}
+		}
+		if rerr != nil {
+			break // io.EOF on clean close, or a read error
+		}
+	}
+
+	close(doneTick)
+	waitErr := cmd.Wait()
+	fmt.Printf("\r\033[KAnalyzing with Claude… complete (%ds).\n", int(time.Since(start).Seconds()))
+
+	if resultEvent != nil {
+		if resultEvent.IsError {
+			msg := resultEvent.Result
+			if msg == "" {
+				msg = resultEvent.Subtype
+			}
+			return "", fmt.Errorf("claude reported an error: %s", msg)
+		}
+		return resultEvent.Result, nil
+	}
+	if waitErr != nil {
+		if stderr.Len() > 0 {
+			return "", fmt.Errorf("claude analysis failed: %w: %s", waitErr, strings.TrimSpace(stderr.String()))
+		}
+		return "", fmt.Errorf("claude analysis failed: %w", waitErr)
+	}
+	return "", fmt.Errorf("claude produced no result event")
 }
 
 // isTerminal reports whether f is an interactive character device (a TTY),

--- a/internal/providers/claude.go
+++ b/internal/providers/claude.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,15 @@ import (
 	"github.com/aaronsb/yay-friend/internal/config"
 	"github.com/aaronsb/yay-friend/internal/types"
 )
+
+// deniedTools lists every built-in Claude Code tool yay-friend forbids during
+// analysis. A PKGBUILD is untrusted input that may attempt prompt injection, so
+// the model must only read and classify the text we hand it — never execute,
+// write, or fetch anything.
+var deniedTools = []string{
+	"Bash", "Edit", "Write", "NotebookEdit", "Read", "Glob", "Grep",
+	"WebFetch", "WebSearch", "Task", "TodoWrite",
+}
 
 // ClaudeProvider implements the AIProvider interface for Claude Code
 type ClaudeProvider struct {
@@ -115,25 +125,38 @@ func (c *ClaudeProvider) AnalyzePKGBUILDWithOptions(ctx context.Context, pkgInfo
 
 	prompt := c.buildSimpleSecurityPrompt(pkgInfo)
 
-	// Debug: Write the full prompt to see what's being sent
-	os.WriteFile("/tmp/claude-final-prompt.txt", []byte(prompt), 0644)
-
-	// Get or create a dedicated directory for claude executions
+	// Get or create a dedicated directory for claude executions. Running from a
+	// neutral directory keeps claude from auto-discovering a project CLAUDE.md or
+	// polluting other conversation histories.
 	claudeWorkDir := c.getClaudeWorkDir()
 	if err := os.MkdirAll(claudeWorkDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create claude work directory: %w", err)
 	}
-	
+
+	// Opt-in prompt dump for debugging, kept out of world-readable /tmp.
+	if os.Getenv("YAYFRIEND_DEBUG") != "" {
+		_ = os.WriteFile(filepath.Join(claudeWorkDir, "last-prompt.txt"), []byte(prompt), 0600)
+	}
+
+	args := c.buildClaudeArgs()
+
 	var output []byte
+	var stderr bytes.Buffer
 	var err error
-	
-	if noSpinner {
-		fmt.Printf("Analyzing with Claude...\n")
-		// No spinner - just run claude directly with --print flag
-		cmd := exec.CommandContext(ctx, c.claudePath, "--print")
-		cmd.Dir = claudeWorkDir // Set working directory to avoid polluting other histories
+
+	runClaude := func() {
+		cmd := exec.CommandContext(ctx, c.claudePath, args...)
+		cmd.Dir = claudeWorkDir // neutral working directory; see above
 		cmd.Stdin = strings.NewReader(prompt)
+		cmd.Stderr = &stderr
 		output, err = cmd.Output()
+	}
+
+	// Only animate the spinner on an interactive terminal; when output is piped
+	// or redirected (automation, CI), the \r-based spinner just spams lines.
+	if noSpinner || !isTerminal(os.Stdout) {
+		fmt.Printf("Analyzing with Claude...\n")
+		runClaude()
 		fmt.Printf("Analysis complete.\n")
 	} else {
 		fmt.Printf("Analyzing with Claude... ")
@@ -156,29 +179,133 @@ func (c *ClaudeProvider) AnalyzePKGBUILDWithOptions(ctx context.Context, pkgInfo
 			}
 		}()
 
-		// Run claude with the prompt via stdin using --print flag for non-interactive mode
-		cmd := exec.CommandContext(ctx, c.claudePath, "--print")
-		cmd.Dir = claudeWorkDir // Set working directory to avoid polluting other histories
-		cmd.Stdin = strings.NewReader(prompt)
-		output, err = cmd.Output()
+		runClaude()
 
 		// Stop spinner and clear line
 		done <- true
 		time.Sleep(10 * time.Millisecond) // Give spinner time to clear
 		fmt.Printf("\rAnalyzing with Claude... Complete!\n")
 	}
-	
+
 	if err != nil {
+		if stderr.Len() > 0 {
+			return nil, fmt.Errorf("claude analysis failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+		}
 		return nil, fmt.Errorf("claude analysis failed: %w", err)
 	}
 
+	// Unwrap the structured JSON envelope to the model's text result.
+	resultText, err := extractClaudeResult(output)
+	if err != nil {
+		return nil, err
+	}
+
 	// Parse the response
-	analysis, err := c.parseAnalysisResponse(string(output), pkgInfo)
+	analysis, err := c.parseAnalysisResponse(resultText, pkgInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse analysis: %w", err)
 	}
 
 	return analysis, nil
+}
+
+// buildClaudeArgs assembles the flags for a hardened, isolated headless call.
+// The invocation is deliberately minimal and locked down:
+//   - --print / --output-format json: non-interactive, structured envelope
+//   - --model: pinned so analysis is reproducible rather than drifting with the
+//     user's interactive default
+//   - --strict-mcp-config + empty --mcp-config: ignore the user's MCP servers so
+//     analysis can't reach Slack, Google, etc.
+//   - --disallowedTools: deny every built-in tool (see deniedTools)
+//
+// Authentication is intentionally left untouched: this inherits whatever the
+// local `claude` is logged into (subscription OAuth or ANTHROPIC_API_KEY).
+// yay-friend never reads, extracts, or forwards credentials.
+func (c *ClaudeProvider) buildClaudeArgs() []string {
+	return []string{
+		"--print",
+		"--output-format", "json",
+		"--model", c.getModel(),
+		"--strict-mcp-config",
+		"--mcp-config", `{"mcpServers":{}}`,
+		"--disallowedTools", strings.Join(deniedTools, ","),
+	}
+}
+
+// isTerminal reports whether f is an interactive character device (a TTY),
+// as opposed to a pipe or regular file.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// getModel returns the configured model alias, or the default.
+func (c *ClaudeProvider) getModel() string {
+	if c.config != nil && c.config.Claude.Model != "" {
+		return c.config.Claude.Model
+	}
+	return config.DefaultClaudeModel
+}
+
+// claudeEvent captures the fields we need from `claude --output-format json`.
+// That format emits either a single result object or (in richer environments) a
+// JSON array of events ending in a result event; extractClaudeResult handles both.
+type claudeEvent struct {
+	Type    string `json:"type"`
+	Subtype string `json:"subtype"`
+	IsError bool   `json:"is_error"`
+	Result  string `json:"result"`
+}
+
+// extractClaudeResult unwraps the JSON envelope from `claude --output-format json`
+// and returns the model's text result. It tolerates three shapes: a JSON array of
+// events, a single result object, or (defensively) raw non-JSON text.
+func extractClaudeResult(output []byte) (string, error) {
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 {
+		return "", fmt.Errorf("claude returned empty output")
+	}
+
+	var result *claudeEvent
+	switch trimmed[0] {
+	case '[':
+		var events []claudeEvent
+		if err := json.Unmarshal(trimmed, &events); err != nil {
+			return "", fmt.Errorf("failed to parse claude event stream: %w", err)
+		}
+		for i := range events {
+			if events[i].Type == "result" {
+				result = &events[i]
+			}
+		}
+	case '{':
+		var ev claudeEvent
+		if err := json.Unmarshal(trimmed, &ev); err != nil {
+			return "", fmt.Errorf("failed to parse claude result: %w", err)
+		}
+		if ev.Type == "result" || ev.Result != "" {
+			result = &ev
+		}
+	default:
+		// Not a JSON envelope (e.g. plain --print text); use as-is.
+		return string(trimmed), nil
+	}
+
+	if result == nil {
+		// No result event found; fall back to raw output so parsing can still try.
+		return string(trimmed), nil
+	}
+	if result.IsError {
+		msg := result.Result
+		if msg == "" {
+			msg = result.Subtype
+		}
+		return "", fmt.Errorf("claude reported an error: %s", msg)
+	}
+	return result.Result, nil
 }
 
 // GetCapabilities returns the provider capabilities

--- a/internal/providers/claude.go
+++ b/internal/providers/claude.go
@@ -17,10 +17,16 @@ import (
 	"github.com/aaronsb/yay-friend/internal/types"
 )
 
-// deniedTools lists every built-in Claude Code tool yay-friend forbids during
+// deniedTools lists the built-in Claude Code tools yay-friend forbids during
 // analysis. A PKGBUILD is untrusted input that may attempt prompt injection, so
-// the model must only read and classify the text we hand it — never execute,
+// the model should only read and classify the text we hand it — not execute,
 // write, or fetch anything.
+//
+// NOTE: this is an enumerated deny-list, current as of Claude Code 2.1.x. It is
+// best-effort, not a hard sandbox: a built-in tool added in a future Claude
+// release would not be covered until added here. It is one layer of
+// defense-in-depth alongside headless mode's own permission checks. If Claude
+// Code ever supports an empty allow-list that fails closed, prefer that.
 var deniedTools = []string{
 	"Bash", "Edit", "Write", "NotebookEdit", "Read", "Glob", "Grep",
 	"WebFetch", "WebSearch", "Task", "TodoWrite",
@@ -187,14 +193,15 @@ func (c *ClaudeProvider) baseClaudeArgs() []string {
 func (c *ClaudeProvider) runClaudeOneShot(ctx context.Context, prompt, workDir string) (string, error) {
 	args := append([]string{"--print", "--output-format", "json"}, c.baseClaudeArgs()...)
 
-	fmt.Println("Analyzing with Claude...")
+	// Status goes to stderr so stdout stays clean for callers capturing output.
+	fmt.Fprintln(os.Stderr, "Analyzing with Claude...")
 	cmd := exec.CommandContext(ctx, c.claudePath, args...)
 	cmd.Dir = workDir
 	cmd.Stdin = strings.NewReader(prompt)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()
-	fmt.Println("Analysis complete.")
+	fmt.Fprintln(os.Stderr, "Analysis complete.")
 
 	if err != nil {
 		if stderr.Len() > 0 {
@@ -230,8 +237,13 @@ func (c *ClaudeProvider) runClaudeStreaming(ctx context.Context, prompt, workDir
 	phase := "starting"
 
 	// Progress ticker: repaint the elapsed/phase line a few times a second.
+	// wg lets us join the goroutine before printing the final line, so a stale
+	// in-progress repaint can never land after "complete".
 	doneTick := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		ticker := time.NewTicker(200 * time.Millisecond)
 		defer ticker.Stop()
 		for {
@@ -248,8 +260,12 @@ func (c *ClaudeProvider) runClaudeStreaming(ctx context.Context, prompt, workDir
 	}()
 
 	// Read events as they arrive. Use a Reader (not Scanner) so a large result
-	// line can't blow past a fixed token limit.
+	// line can't blow past a fixed token limit. We also accumulate the assistant
+	// message text: it carries the same JSON as the result event, so it's a
+	// fallback if the result event is missing or unparseable (parity with the
+	// one-shot path, which falls back to raw text).
 	var resultEvent *claudeEvent
+	var assistantText strings.Builder
 	reader := bufio.NewReader(stdout)
 	for {
 		line, rerr := reader.ReadString('\n')
@@ -261,6 +277,11 @@ func (c *ClaudeProvider) runClaudeStreaming(ctx context.Context, prompt, workDir
 					mu.Lock()
 					phase = "receiving"
 					mu.Unlock()
+					for _, block := range ev.Message.Content {
+						if block.Type == "text" {
+							assistantText.WriteString(block.Text)
+						}
+					}
 				case "result":
 					e := ev
 					resultEvent = &e
@@ -273,6 +294,7 @@ func (c *ClaudeProvider) runClaudeStreaming(ctx context.Context, prompt, workDir
 	}
 
 	close(doneTick)
+	wg.Wait()
 	waitErr := cmd.Wait()
 	fmt.Printf("\r\033[KAnalyzing with Claude… complete (%ds).\n", int(time.Since(start).Seconds()))
 
@@ -285,6 +307,10 @@ func (c *ClaudeProvider) runClaudeStreaming(ctx context.Context, prompt, workDir
 			return "", fmt.Errorf("claude reported an error: %s", msg)
 		}
 		return resultEvent.Result, nil
+	}
+	// No usable result event; fall back to the assistant text if we captured any.
+	if text := strings.TrimSpace(assistantText.String()); text != "" {
+		return text, nil
 	}
 	if waitErr != nil {
 		if stderr.Len() > 0 {
@@ -321,6 +347,14 @@ type claudeEvent struct {
 	Subtype string `json:"subtype"`
 	IsError bool   `json:"is_error"`
 	Result  string `json:"result"`
+	// Message is populated only on "assistant" events in the stream-json format;
+	// its text blocks carry the model's output.
+	Message struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"message"`
 }
 
 // extractClaudeResult unwraps the JSON envelope from `claude --output-format json`

--- a/internal/providers/claude_test.go
+++ b/internal/providers/claude_test.go
@@ -1,0 +1,76 @@
+package providers
+
+import "testing"
+
+func TestExtractClaudeResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "array envelope with result event",
+			output: `[{"type":"system","subtype":"init"},{"type":"assistant"},{"type":"result","subtype":"success","is_error":false,"result":"{\"ok\":true}"}]`,
+			want:   `{"ok":true}`,
+		},
+		{
+			name:   "single result object",
+			output: `{"type":"result","subtype":"success","is_error":false,"result":"{\"ok\":true}"}`,
+			want:   `{"ok":true}`,
+		},
+		{
+			name:    "result event with is_error",
+			output:  `[{"type":"result","subtype":"error_during_execution","is_error":true,"result":"boom"}]`,
+			wantErr: true,
+		},
+		{
+			name:    "empty output",
+			output:  "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only output",
+			output:  "   \n\t ",
+			wantErr: true,
+		},
+		{
+			name:   "non-JSON text falls back to raw",
+			output: "here is some analysis {\"ok\":true}",
+			want:   `here is some analysis {"ok":true}`,
+		},
+		{
+			name:   "array with multiple result events keeps the last",
+			output: `[{"type":"result","result":"first"},{"type":"result","result":"last"}]`,
+			want:   `last`,
+		},
+		{
+			name:   "array with no result event falls back to raw",
+			output: `[{"type":"system"},{"type":"assistant"}]`,
+			want:   `[{"type":"system"},{"type":"assistant"}]`,
+		},
+		{
+			name:    "malformed JSON array errors",
+			output:  `[{"type":"result",`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractClaudeResult([]byte(tt.output))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got result %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -153,6 +153,9 @@ type Config struct {
 		Path  string   `yaml:"path"`
 		Flags []string `yaml:"default_flags"`
 	} `yaml:"yay"`
+	Claude struct {
+		Model string `yaml:"model"` // model alias passed to `claude --model` (e.g. "sonnet", "opus")
+	} `yaml:"claude"`
 }
 
 // YayOperation represents the operation to perform with yay


### PR DESCRIPTION
## Why

yay-friend hadn't been touched in ~10 months. This modernizes how it drives
Claude Code and documents the authentication/cost model that was previously
unstated — the ambiguity that made the tool feel risky to run.

**The headline: yay-friend never touches your credentials.** It shells out to
the official `claude` binary in supported headless mode and lets Claude Code
manage its own auth. Works on a Claude subscription (no API key required) or an
`ANTHROPIC_API_KEY`. It does not extract, store, or replay any token — the
opposite of the credential-exfiltration pattern that gets accounts flagged.

## What changed

### Hardened + isolated invocation (`internal/providers/claude.go`)
- Parse the structured `--output-format json` envelope (array or single object;
  honor `is_error`) instead of scraping the reply for `{`…`}`.
- **Lock the call down**: `--strict-mcp-config` + empty `--mcp-config` disables
  the user's MCP servers, and `--disallowedTools` denies every built-in tool, so
  an untrusted (possibly prompt-injecting) PKGBUILD can be read and classified
  but can never make Claude execute anything.
- Pin `--model` (configurable via `claude.model`, default `sonnet`) for
  reproducible analysis.
- Remove the unconditional world-readable `/tmp/claude-final-prompt.txt` dump;
  make it opt-in via `YAYFRIEND_DEBUG` (0600, in the work dir).
- Capture stderr for clearer failure messages.

### Live streaming progress — closes #3
- On a TTY, drive Claude with `--output-format stream-json --verbose` and render
  a live `Analyzing with Claude (Ns, <phase>)…` line (starting → receiving →
  done) while capturing the final result event for parsing.
- Non-TTY / no-spinner callers keep a quiet one-shot path (clean for automation).
- stdout and stderr read on separate pipes so a chatty stderr can't deadlock the
  reader — the pitfall noted in the issue.

### Config + build + docs
- `claude.model` config field, default `sonnet` (`internal/types`, `internal/config`).
- go 1.21 → 1.23; `build`, `vet`, `test` all pass.
- README: new **Authentication & Cost** section; reconciled the stale
  "multiple providers" claim (Qwen/Copilot/Goose are still stubs); honest caveat
  that config-file loading is stubbed (#5), so defaults are authoritative.

## Testing
- `go build`, `go vet ./...`, `go test ./...` green.
- End-to-end live analyses of `yay-bin` (one-shot path) and `paru-bin` (streaming
  path under a PTY) — both parsed correctly to MINIMAL / PROCEED.

## Follow-ups (not in this PR)
- #5 — wire up YAML config loading so `claude.model` / prompt edits take effect.
- #6 — AUR comment/community analysis (timely given recent AUR attacks).
