### PR TITLE
Fix interactive yay handoff + flag leakage on install

### DIFF
--- a/internal/cmd/yay_style.go
+++ b/internal/cmd/yay_style.go
@@ -2,10 +2,37 @@ package cmd
 
 import (
 	"context"
+	"strings"
 )
 
-// RunYayStyleCommand handles yay-style commands directly without cobra
+// RunYayStyleCommand handles yay-style commands directly without cobra.
+//
+// Because main.go routes yay-style invocations here (bypassing cobra's flag
+// parsing), yay-friend's own flags mixed into the command line would otherwise
+// leak through to yay. We extract them here, set the corresponding globals, and
+// pass only the remaining arguments on to yay.
 func RunYayStyleCommand(ctx context.Context, args []string) error {
-	// This is essentially the same as runInstall, but called directly
-	return runInstall(ctx, args)
+	passthrough := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--skip-analysis":
+			skipAnalysis = true
+		case arg == "--no-spinner":
+			noSpinner = true
+		case arg == "-v" || arg == "--verbose":
+			verbose = true
+		case arg == "--provider":
+			if i+1 < len(args) {
+				provider = args[i+1]
+				i++ // consume the value
+			}
+		case strings.HasPrefix(arg, "--provider="):
+			provider = strings.TrimPrefix(arg, "--provider=")
+		default:
+			passthrough = append(passthrough, arg)
+		}
+	}
+
+	return runInstall(ctx, passthrough)
 }

--- a/internal/yay/yay.go
+++ b/internal/yay/yay.go
@@ -76,9 +76,12 @@ func (y *YayClient) InstallPackages(ctx context.Context, operation *types.YayOpe
 	args = append(args, operation.Packages...)
 
 	cmd := exec.CommandContext(ctx, y.yayPath, args...)
-	cmd.Stdout = nil // Let it inherit our stdout for interactive behavior
-	cmd.Stderr = nil // Let it inherit our stderr
-	cmd.Stdin = nil  // Let it inherit our stdin
+	// Wire yay directly to our terminal so it can run interactively — sudo
+	// password, PKGBUILD review, and confirmation prompts. (In os/exec, a nil
+	// std stream means /dev/null, not "inherit"; we must assign os.Std* here.)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
 }


### PR DESCRIPTION
Fixes two bugs that made installing via yay-friend unusable (found while installing the freshly-published `yay-friend-git`).

**1. Opaque `exit status 1` on install (the reported bug).** `InstallPackages` set `cmd.Stdin/Stdout/Stderr = nil` believing that inherits the terminal. In Go's `os/exec`, nil = `/dev/null`: yay got EOF on stdin (no sudo/confirm input) and its output was discarded → silent failure. Now wired to `os.Std*`, so yay runs fully interactively — matching the pattern already correct in the interactive-search path (yay.go:140-142).

**2. `--skip-analysis` (and `--provider`/`--no-spinner`/`--verbose`) leaked to yay.** yay-style commands bypass cobra (main.go), so these flags passed straight through (`invalid option 'skip-analysis'`) and `--skip-analysis` never worked. `RunYayStyleCommand` now strips them before handing args to yay.

**Verified** end-to-end under a PTY: analyze→install reaches yay's interactive `cleanBuild`/`Diffs`/confirm menus; `--skip-analysis -S <pkg>` forwards clean args to yay.