### PR TITLE
Fix entropy calibration + revive dead analysis fields

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -299,19 +299,43 @@ func validateConfig(cfg *types.Config) error {
 
 // GetDefaultSecurityPrompt returns the default security analysis prompt template
 func GetDefaultSecurityPrompt() string {
-	return `You are a security expert analyzing AUR packages for malicious behavior. Your PRIMARY goal is to detect and flag dangerous code patterns.
+	return `You are a security analyst reviewing an AUR (Arch User Repository) package before a user installs it. You have two jobs:
+
+1. DETECT MALICE: scan every file for the malicious patterns below and state plainly whether any are present.
+2. GRADE ENTROPY: score how predictable vs. chaotic the package is. Entropy measures UNCERTAINTY, not guilt. A low-entropy package is predictable and boring; a high-entropy one means "pay attention," not necessarily "malicious." Malicious patterns always imply high entropy; high entropy does not imply malice.
 
 <critical_patterns>
-SCAN FOR THESE MALICIOUS PATTERNS FIRST:
-1. curl/wget piped to shell: curl URL | sh, wget -O- URL | bash
-2. Downloading and executing code: python -c "$(curl ...)", eval "$(wget ...)"
-3. Base64/hex encoded commands: echo BASE64 | base64 -d | sh
-4. Commands in install hooks: post_install() running executables
-5. Suspicious URLs: URL shorteners, paste sites, non-official domains
-6. Hidden network activity: Background downloads, data exfiltration
-7. System modification: Writing to /usr/bin during build, modifying system files
-8. Obfuscated scripts: Encoded strings, complex redirections, hidden commands
+These are genuinely dangerous. If any is present, it drives HIGH or CRITICAL entropy and a REVIEW/BLOCK recommendation:
+1. Download-and-execute: curl/wget piped to a shell (curl URL | sh), python -c "$(curl ...)", eval "$(wget ...)"
+2. Encoded/obfuscated commands: base64/hex/gzip decoded then executed, eval of assembled strings, deliberately obscured redirections
+3. Executable code in install hooks: post_install/post_upgrade/pre_install in a .install file that runs binaries, fetches remote code, or modifies the live system
+4. Suspicious sources: URL shorteners, paste sites, IP-literal or non-official domains that don't match the stated upstream
+5. Hidden network activity or data exfiltration: background downloads, POSTing local data, contacting unexpected hosts
+6. Writing outside the package sandbox: modifying the live filesystem (anything not under $pkgdir/$srcdir) during build()/package()
 </critical_patterns>
+
+<normal_for_aur>
+These are EXPECTED and are NOT elevated on their own. Treat them as MINIMAL unless combined with a critical pattern above:
+- Compiling from source: build() running make/cargo/go build/etc. Build-time code execution is not install-time execution.
+- SKIP checksums on a VCS source (git/hg/svn): standard; the revision/commit is the integrity pin.
+- Fetching source and language dependencies at build time (git clone of the declared repo, go mod / cargo / npm downloads): expected build activity, not exfiltration.
+- Installing only into $pkgdir (install -D of the binary, license, docs, systemd units): the correct, sandboxed packaging pattern.
+- The ABSENCE of an .install script: a positive signal — there is no install-time code path.
+</normal_for_aur>
+
+<entropy_scale>
+Grade the overall package and each finding on this scale. Anchor to what the level MEANS, not to how many observations you can list:
+- MINIMAL: predictable, expected, best-practice or benign. Nothing to act on.
+- LOW: minor, well-understood uncertainty (e.g. md5 instead of sha256 checksums, source compilation from a trusted upstream).
+- MODERATE: concrete factors a careful user should glance at before installing — NOT evidence of malice (e.g. several third-party sources, a brand-new package with little community vetting as one contributing factor).
+- HIGH: multiple risky factors or probably-unsafe behavior (install-time hooks running scripts, non-official download URLs, partial obfuscation, writes to system paths).
+- CRITICAL: an active malicious pattern from critical_patterns is present.
+
+Calibration rules (follow strictly):
+- A finding's entropy is the risk of THAT finding alone. If your suggestion is effectively "no action needed / this is correct," the finding's entropy MUST be MINIMAL. Never tag expected, best-practice behavior as MODERATE or above.
+- Overall entropy is driven by the single most concerning REAL factor, not the number of observations. A package whose findings are all MINIMAL is MINIMAL overall.
+- A clean package commonly has only MINIMAL findings, or none. Do not manufacture concern to fill the list.
+</entropy_scale>
 
 <package_context>
 Name: {NAME} | Version: {VERSION} | Maintainer: {MAINTAINER}
@@ -334,36 +358,37 @@ Build Dependencies: {MAKE_DEPENDS}
 </additional_files>
 
 <analysis_instructions>
-1. FIRST check ALL files for the critical patterns listed above
-2. Pay special attention to .install scripts and helper scripts
-3. Look for ANY network activity (curl, wget, git clone during runtime)
-4. Check for code execution during install/upgrade hooks
-5. Verify all URLs point to official/trusted sources
-6. Flag ANY obfuscation or encoding of commands
+1. Scan ALL files (PKGBUILD, .install, helper scripts) for the critical_patterns first.
+2. Pay closest attention to .install hooks — they are the most common execution vector.
+3. Confirm every source/URL matches the declared upstream and uses HTTPS or a pinned VCS revision.
+4. Separate build-time activity (normal) from install-time and runtime activity (higher scrutiny).
+5. Grade each finding and the overall package against the entropy_scale, following the calibration rules.
+6. predictability_score is a 0.0-1.0 number: 0.0 = fully chaotic/unpredictable, 1.0 = fully predictable. It is roughly the inverse of overall entropy.
 </analysis_instructions>
 
 <response_format>
-Provide ONLY a JSON response:
+Respond with ONLY a JSON object — no prose before or after it. Field values below describe what to put there:
 {
   "overall_entropy": "MINIMAL|LOW|MODERATE|HIGH|CRITICAL",
-  "summary": "Clear statement of findings, especially any malicious code",
+  "predictability_score": 0.9,
+  "summary": "Plain statement of what the package does and whether it is safe; lead with any malicious finding",
   "recommendation": "PROCEED|REVIEW|BLOCK",
   "findings": [
     {
       "type": "malicious_code|suspicious_behavior|source_analysis|build_process|file_operations|maintainer_trust|dependency_analysis",
       "entropy": "MINIMAL|LOW|MODERATE|HIGH|CRITICAL",
-      "description": "Specific description of the threat",
-      "context": "Exact code snippet showing the issue",
+      "description": "What you observed",
+      "context": "Exact code snippet, if applicable",
       "line_number": 0,
-      "file": "filename where found (PKGBUILD, .install, etc)",
-      "suggestion": "Remove this package immediately / Review before installing / etc"
+      "entropy_notes": "One line: why this entropy level (if MINIMAL, say why it is fine)",
+      "suggestion": "What the user should do, or 'No action needed'"
     }
   ],
-  "entropy_factors": ["list of specific risk factors found"],
-  "educational_summary": "What this attack vector teaches about AUR security",
-  "security_lessons": ["Key takeaways for users"]
+  "entropy_factors": ["the specific factors driving the overall score"],
+  "educational_summary": "What this package teaches about AUR security",
+  "security_lessons": ["Key takeaways for the user"]
 }
 </response_format>
 
-REMEMBER: Any code execution during installation, hidden network requests, or obfuscated commands should result in CRITICAL entropy and BLOCK recommendation.`
+Recommendation mapping: BLOCK if any CRITICAL malicious pattern is present; REVIEW if HIGH, or if a genuine MODERATE concern warrants a human look; otherwise PROCEED. Never inflate entropy or block for behavior listed in normal_for_aur.`
 }

--- a/internal/providers/claude.go
+++ b/internal/providers/claude.go
@@ -484,8 +484,9 @@ func (c *ClaudeProvider) parseAnalysisResponse(response string, pkgInfo types.Pa
 	
 	// Convert to our types
 	overallEntropy := parseSecurityEntropy(analysisData.OverallEntropy)
-	if overallEntropy == types.EntropyMinimal && analysisData.OverallLevel != "" {
-		// Fallback to overall_level if entropy not provided
+	if analysisData.OverallEntropy == "" && analysisData.OverallLevel != "" {
+		// Only fall back to the legacy overall_level when overall_entropy is
+		// genuinely absent — a real "MINIMAL" must not trigger the fallback.
 		overallEntropy = parseSecurityEntropy(analysisData.OverallLevel)
 	}
 
@@ -505,8 +506,11 @@ func (c *ClaudeProvider) parseAnalysisResponse(response string, pkgInfo types.Pa
 	
 	for _, finding := range analysisData.Findings {
 		entropy := parseSecurityEntropy(finding.Entropy)
-		if entropy == types.EntropyMinimal {
-			// Fallback to severity if entropy not provided
+		if finding.Entropy == "" && finding.Severity != "" {
+			// Only fall back to the legacy severity field when entropy is
+			// absent. Previously ANY finding parsed to MINIMAL hit this branch
+			// and, with severity empty, defaulted to MODERATE — silently
+			// promoting every benign finding a level or more.
 			entropy = parseSecurityEntropy(finding.Severity)
 		}
 		
@@ -541,11 +545,6 @@ func parseSecurityEntropy(level string) types.SecurityEntropy {
 	default:
 		return types.EntropyModerate
 	}
-}
-
-// parseSecurityLevel converts string to SecurityLevel (legacy compatibility)
-func parseSecurityLevel(level string) types.SecurityLevel {
-	return parseSecurityEntropy(level) // They're the same type now
 }
 
 // buildSimpleSecurityPrompt creates a prompt using the config template


### PR DESCRIPTION
Follow-up from dogfooding `yay-friend yay-friend-git`: benign findings were rated 🟡 MODERATE, and `Predictability Score` / per-finding `Analysis:` notes never appeared.

## Root cause was the parser, not just the prompt
- `parseAnalysisResponse` treated a model-provided `"MINIMAL"` as *entropy missing* and fell back to the legacy `severity` field. The prompt has never emitted `severity`, so `parseSecurityEntropy("")` hit its **MODERATE default** — silently promoting **every** benign finding. Longstanding bug (explains the old `hello` example too). Fixed to fall back only when the entropy string is genuinely absent; same guard on the overall score.
- The prompt never requested `predictability_score` or per-finding `entropy_notes`, yet the parser reads them and the display prints them (root.go:317, :375) → always blank. It also requested a `file` field the parser ignores. The prompt now emits exactly what the parser consumes.

## Prompt rewrite
- Explicit **entropy-level rubric** + calibration rules ("no action needed ⇒ MINIMAL"; overall = worst real factor, not observation count).
- `normal_for_aur` section so build-time compilation, VCS `SKIP` checksums, and sandboxed `package()` aren't treated as install-time risks.
- Reframes entropy as *uncertainty* ("pay attention"), not guilt, per the README philosophy.
- Removed dead `parseSecurityLevel`.

## Verified
Fresh analysis of `yay-friend-git`: findings now 🟢 MINIMAL with justifying `Analysis:` notes, `Predictability Score: 0.85/1.0` populated, overall 🟢 LOW off the single newness factor.