### PR TITLE
Native pacrat-grade/v1: the grade subcommand and analyze --json

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ to run the analysis twice to see what the analyzer actually said.
 stores the level as its integer, and a one-line `jq` filter usually wants the
 name and the bounds without having to know the enum.
 
+This is what makes yay-friend usable as a pacrat grader *without* the native
+`grade` subcommand — the shape a tool that has never heard of pacrat would
+pipe into place. The whole adapter is one filter:
+
+```toml
+[[graders]]
+name = "yay-friend-pipe"
+cmd = """yay-friend analyze --file "$PACRAT_TREE" --json | jq '{
+  contract: "pacrat-grade/v1", grader: "yay-friend-pipe",
+  subject: {package: env.PACRAT_PACKAGE, commit: env.PACRAT_COMMIT},
+  grade: .entropy.value, scale: {min: .entropy.min, max: .entropy.max},
+  findings: [], meta: {note: .analysis.summary}}'"""
+timeout_s = 600
+```
+
+Real, runnable, and deliberately the worse option — it drops the findings and
+re-analyzes without pacrat's commit-keyed replay — because its job is to show
+the *shape* of adapting an unknowing tool, next to the one-string registration
+below for a tool that speaks the contract itself.
+
 #### `grade`
 
 [pacrat](https://github.com/aaronsb/pacrat) gates AUR updates on a grade from

--- a/README.md
+++ b/README.md
@@ -135,6 +135,56 @@ yay-friend config show
 yay-friend --skip-analysis -S package-name
 ```
 
+### Grading a Tree for pacrat
+
+[pacrat](https://github.com/aaronsb/pacrat) gates AUR updates on a grade from
+any program that speaks `pacrat-grade/v1`. `yay-friend grade` speaks it natively,
+so registering it is one line:
+
+```toml
+[[graders]]
+name = "yay-friend"
+cmd = "yay-friend grade"
+timeout_s = 600
+scale = { min = 0, max = 4 }
+```
+
+The subject arrives in the environment — `PACRAT_PACKAGE`, `PACRAT_TREE`,
+`PACRAT_COMMIT` — and `--package/--tree/--commit` override it, so you can drive
+the same command by hand:
+
+```bash
+PACRAT_PACKAGE=hello PACRAT_TREE=/path/to/tree PACRAT_COMMIT=51cec63… yay-friend grade
+```
+
+What gets read is the tree you were handed: the PKGBUILD pacrat staged, its
+`.install` hook and any file shipped beside it, not a fresh fetch of whatever
+the AUR is serving now. The result is filed in the usual cache under (package,
+commit), so a second ask about the same tree replays instead of calling a model.
+
+```json
+{ "contract": "pacrat-grade/v1",
+  "grader": "yay-friend",
+  "subject": { "package": "hello", "commit": "51cec63…", "version": "2.12.1-1" },
+  "grade": 1,
+  "scale": { "min": 0, "max": 4 },
+  "findings": [ { "level": 2, "title": "source_analysis: …", "span": "PKGBUILD:12" } ],
+  "meta": { "cached": true, "provider": "claude", "note": "Clean package.",
+            "recommendation": "PROCEED", "yay_friend_version": "1.0.0" } }
+```
+
+stdout carries exactly one JSON object and everything yay-friend narrates moves
+to stderr, so you can pipe the grading and still watch the run.
+
+`grade` is entropy, on 0-4, and only that. PROCEED / WARN / BLOCK is pacrat's to
+derive with the host's own thresholds; yay-friend's own recommendation rides
+along in `meta`, where it is advisory and cannot move a verdict.
+
+Any failure — no provider configured, the model unreachable, an unreadable tree,
+an entropy that will not fit the scale — is a nonzero exit with the reason on
+stderr and **no JSON at all**. pacrat reads that as UNGRADED, which holds; a
+half-report is worse than none.
+
 ### Cache Management
 `yay-friend` intelligently caches analysis results using AUR git commit hashes to avoid redundant AI calls for unchanged packages.
 
@@ -276,6 +326,10 @@ wear it, so you can always tell which lines came from the analyzer.
 - **Entropy Analysis Engine**: Multi-factor security assessment
 - **Provider Interface**: Modular AI backend system
 - **Configuration Management**: User preferences and thresholds
+- **Grading Contract** (`internal/grade`): translation of an analysis into
+  `pacrat-grade/v1`, and the whole of yay-friend's side of that boundary — the
+  contract is a JSON shape, so speaking it is a marshalling concern and stays
+  well away from the analyzer
 
 ## Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,47 @@ yay-friend config show
 yay-friend --skip-analysis -S package-name
 ```
 
-### Grading a Tree for pacrat
+### Machine-Readable Output
+
+Two shapes, for two different callers. With either, stdout carries exactly one
+JSON object and everything yay-friend narrates moves to stderr, so you can pipe
+the output and still watch the run.
+
+```bash
+# yay-friend's own shape: the whole analysis
+yay-friend analyze hello --json
+yay-friend analyze --file ./my-package --json
+
+# pacrat's shape: a grading of a staged tree
+PACRAT_PACKAGE=hello PACRAT_TREE=/path/to/tree PACRAT_COMMIT=51cec63… yay-friend grade
+```
+
+#### `analyze --json`
+
+The full analysis, plus the context it was produced in. Deliberately richer than
+any grading contract: it keeps the educational summary, the security lessons,
+the predictability score, the per-finding suggestions and entropy notes, and the
+AUR community numbers, because a caller shaping its own pipeline should not have
+to run the analysis twice to see what the analyzer actually said.
+
+```jsonc
+{
+  "yay_friend_version": "1.0.0",
+  "source": "aur",              // or "local", for --file
+  "cached": true,               // replayed from the analysis cache
+  "package": { "name": "hello", "version": "2.12.1", "commit_hash": "51cec63…",
+               "maintainer": "…", "votes": 12, "popularity": 0.31,
+               "files": ["hello.install"] },   // companion files that were read
+  "entropy": { "value": 1, "name": "LOW", "min": 0, "max": 4 },
+  "analysis": { /* the complete SecurityAnalysis, as the cache stores it */ }
+}
+```
+
+`entropy` is redundant with `analysis.overall_entropy` on purpose: the analysis
+stores the level as its integer, and a one-line `jq` filter usually wants the
+name and the bounds without having to know the enum.
+
+#### `grade`
 
 [pacrat](https://github.com/aaronsb/pacrat) gates AUR updates on a grade from
 any program that speaks `pacrat-grade/v1`. `yay-friend grade` speaks it natively,
@@ -172,9 +212,6 @@ commit), so a second ask about the same tree replays instead of calling a model.
   "meta": { "cached": true, "provider": "claude", "note": "Clean package.",
             "recommendation": "PROCEED", "yay_friend_version": "1.0.0" } }
 ```
-
-stdout carries exactly one JSON object and everything yay-friend narrates moves
-to stderr, so you can pipe the grading and still watch the run.
 
 `grade` is entropy, on 0-4, and only that. PROCEED / WARN / BLOCK is pacrat's to
 derive with the host's own thresholds; yay-friend's own recommendation rides

--- a/cmd/yay-friend/main.go
+++ b/cmd/yay-friend/main.go
@@ -19,7 +19,7 @@ func main() {
 	if len(os.Args) > 1 {
 		firstArg := os.Args[1]
 		// Known subcommands that should use cobra
-		knownCommands := []string{"analyze", "config", "provider", "cache", "version", "help", "completion", "--help", "-h", "--version"}
+		knownCommands := []string{"analyze", "grade", "config", "provider", "cache", "version", "help", "completion", "--help", "-h", "--version"}
 		
 		isKnownCommand := false
 		for _, cmdName := range knownCommands {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -76,7 +76,7 @@ func (c *CacheManager) GetCachedAnalysis(packageName, commitHash string) (*types
 
 	// Check if cache file exists
 	if _, err := os.Stat(cacheFile); os.IsNotExist(err) {
-		return nil, fmt.Errorf("cache miss: no cached analysis found for %s@%s", packageName, commitHash[:8])
+		return nil, fmt.Errorf("cache miss: no cached analysis found for %s@%s", packageName, ShortHash(commitHash))
 	}
 
 	// Read and parse cached analysis
@@ -261,6 +261,17 @@ func (c *CacheManager) GetPackageVersions(packageName string) ([]string, error) 
 	sort.Strings(versions)
 
 	return versions, nil
+}
+
+// ShortHash abbreviates a commit hash for display. It does not assume a full
+// 40-character object id: a hash can arrive already abbreviated (pacrat's
+// grading contract accepts seven characters and up), and a fixed [:8] slice
+// panics on one.
+func ShortHash(commitHash string) string {
+	if len(commitHash) <= 8 {
+		return commitHash
+	}
+	return commitHash[:8]
 }
 
 // getCacheFilePath returns the full path for a cache file

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -72,6 +72,19 @@ func NewCacheManager() (*CacheManager, error) {
 
 // GetCachedAnalysis retrieves a cached analysis if it exists
 func (c *CacheManager) GetCachedAnalysis(packageName, commitHash string) (*types.SecurityAnalysis, error) {
+	cached, err := c.GetCachedEntry(packageName, commitHash)
+	if err != nil {
+		return nil, err
+	}
+	return cached.Analysis, nil
+}
+
+// GetCachedEntry retrieves a cached entry with its metadata, validating that
+// the entry is what its filename claims. Both identity fields are checked: a
+// copied or hand-edited entry declaring another package or commit is a
+// grading of something else wearing the right filename, and replaying it
+// would launder that analysis into an answer about this package.
+func (c *CacheManager) GetCachedEntry(packageName, commitHash string) (*CachedAnalysis, error) {
 	cacheFile := c.getCacheFilePath(packageName, commitHash)
 
 	// Check if cache file exists
@@ -94,8 +107,13 @@ func (c *CacheManager) GetCachedAnalysis(packageName, commitHash string) (*types
 	if cached.CacheMetadata.CommitHash != commitHash {
 		return nil, fmt.Errorf("cache corruption: commit hash mismatch")
 	}
+	// Validate the package too — same reasoning, same consequence
+	if cached.CacheMetadata.PackageName != packageName {
+		return nil, fmt.Errorf("cache corruption: entry declares package %q, not %q",
+			cached.CacheMetadata.PackageName, packageName)
+	}
 
-	return cached.Analysis, nil
+	return &cached, nil
 }
 
 // SaveAnalysis saves an analysis result to cache

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -295,5 +297,51 @@ func TestValidateCommitHash(t *testing.T) {
 		if result != test.valid {
 			t.Errorf("ValidateCommitHash(%q) = %v, expected %v", test.hash, result, test.valid)
 		}
+	}
+}
+// A copied or hand-edited entry declaring another package is a grading of
+// something else wearing the right filename; replaying it would launder that
+// analysis into an answer about this package. The adapter refuses this exact
+// input, and the native path must agree.
+func TestACachedEntryDeclaringAnotherPackageIsRefused(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "yay-friend-cache-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	cacheManager := &CacheManager{cacheDir: tmpDir}
+
+	commitHash := "1234567890abcdef1234567890abcdef12345678"
+	analysis := &types.SecurityAnalysis{
+		PackageName: "evil-other",
+		Summary:     "an analysis of a different package",
+		AnalyzedAt:  time.Now(),
+	}
+	// Filed under hello's name, declaring evil-other inside — the tampered
+	// shape, built through the real writer and then re-labelled by hand.
+	if err := cacheManager.SaveAnalysis("evil-other", commitHash, analysis); err != nil {
+		t.Fatal(err)
+	}
+	src := cacheManager.getCacheFilePath("evil-other", commitHash)
+	dst := cacheManager.getCacheFilePath("hello", commitHash)
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cacheManager.GetCachedEntry("hello", commitHash); err == nil {
+		t.Fatal("a cache entry declaring another package was replayed")
+	} else if !strings.Contains(err.Error(), "evil-other") {
+		t.Errorf("the refusal does not name the declared package: %v", err)
+	}
+	// The un-tampered entry still replays under its own name.
+	if _, err := cacheManager.GetCachedEntry("evil-other", commitHash); err != nil {
+		t.Errorf("the honest entry stopped replaying: %v", err)
 	}
 }

--- a/internal/cmd/analyze.go
+++ b/internal/cmd/analyze.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -17,8 +18,19 @@ import (
 
 var fileFlag string
 
+// analyzeOutput carries where an analysis should be written and in what shape.
+// The rendered report and the JSON report are the same analysis; only the
+// presentation differs, so every path builds one of these and hands it to
+// present at the end.
+type analyzeOutput struct {
+	asJSON bool
+	out    io.Writer
+}
+
 // newAnalyzeCmd creates the analyze command
 func newAnalyzeCmd() *cobra.Command {
+	var jsonFlag bool
+
 	cmd := &cobra.Command{
 		Use:   "analyze <package-or-path>",
 		Short: "Analyze a package without installing it",
@@ -28,25 +40,43 @@ This is useful for checking packages before deciding whether to install them.
 You can analyze:
   - AUR packages by name: yay-friend analyze package-name
   - Local PKGBUILD files: yay-friend analyze --file /path/to/PKGBUILD
-  - Local directories: yay-friend analyze --file /path/to/package-dir/`,
-		Args: cobra.MaximumNArgs(1),
+  - Local directories: yay-friend analyze --file /path/to/package-dir/
+
+With --json, the full analysis is written to stdout as JSON and everything else
+goes to stderr. That shape is yay-friend's own and carries more than any grading
+contract does; for a pacrat-grade/v1 report, use "yay-friend grade".`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if fileFlag != "" {
-				return runAnalyzeLocal(cmd.Context(), fileFlag)
+			out := analyzeOutput{asJSON: jsonFlag, out: cmd.OutOrStdout()}
+			if jsonFlag {
+				// stdout carries the analysis and nothing else. Every byte
+				// yay-friend narrates moves to stderr, where a machine reader
+				// can ignore it and a human can still watch.
+				ui.Out = cmd.ErrOrStderr()
+			} else {
+				ui.Out = cmd.OutOrStdout()
 			}
-			if len(args) == 0 {
-				return fmt.Errorf("please specify a package name or use --file flag")
-			}
-			return runAnalyze(cmd.Context(), args[0])
+
+			return withUsage(cmd, func() error {
+				if fileFlag != "" {
+					return runAnalyzeLocal(cmd.Context(), fileFlag, out)
+				}
+				if len(args) == 0 {
+					return usageError{fmt.Errorf("please specify a package name or use --file flag")}
+				}
+				return runAnalyze(cmd.Context(), args[0], out)
+			})
 		},
 	}
 
 	cmd.Flags().StringVar(&fileFlag, "file", "", "Analyze a local PKGBUILD file or directory")
+	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Emit the full analysis as JSON on stdout")
 
 	return cmd
 }
 
-func runAnalyze(ctx context.Context, packageName string) error {
+func runAnalyze(ctx context.Context, packageName string, out analyzeOutput) error {
 	// Load configuration
 	cfg, err := config.Load()
 	if err != nil {
@@ -88,11 +118,13 @@ func runAnalyze(ctx context.Context, packageName string) error {
 
 	// Check cache first if enabled and we have commit hash and cache manager
 	var analysis *types.SecurityAnalysis
+	cached := false
 	if cfg.Cache.Enabled && cacheManager != nil && pkgInfo.CommitHash != "" {
 		cachedAnalysis, cacheErr := cacheManager.GetCachedAnalysis(pkgInfo.Name, pkgInfo.CommitHash)
 		if cacheErr == nil {
 			ui.Say("using cached analysis (commit %s)", cache.ShortHash(pkgInfo.CommitHash))
 			analysis = cachedAnalysis
+			cached = true
 		} else {
 			ui.Say("running fresh analysis (commit %s)", cache.ShortHash(pkgInfo.CommitHash))
 			// Cache miss - continue to run AI analysis
@@ -104,7 +136,7 @@ func runAnalyze(ctx context.Context, packageName string) error {
 		// Display what we collected for analysis
 		ui.RenderCollected(pkgInfo)
 
-		analysis, err = analyzeWith(ctx, aiProvider, *pkgInfo, false)
+		analysis, err = analyzeWith(ctx, aiProvider, *pkgInfo, out.asJSON)
 		if err != nil {
 			return fmt.Errorf("analysis failed: %w", err)
 		}
@@ -117,14 +149,11 @@ func runAnalyze(ctx context.Context, packageName string) error {
 		}
 	}
 
-	// Display detailed results
-	ui.RenderAnalysis(analysis, true)
-
-	return nil
+	return present(out, sourceAUR, pkgInfo, analysis, cached)
 }
 
 // runAnalyzeLocal analyzes a local PKGBUILD file or directory
-func runAnalyzeLocal(ctx context.Context, path string) error {
+func runAnalyzeLocal(ctx context.Context, path string, out analyzeOutput) error {
 	// Load configuration
 	cfg, err := config.Load()
 	if err != nil {
@@ -148,6 +177,7 @@ func runAnalyzeLocal(ctx context.Context, path string) error {
 	if err != nil {
 		return err
 	}
+	pkgInfo.PKGBUILDPath = pkgbuildPath
 
 	// Display what we collected for analysis
 	ui.RenderCollected(&pkgInfo)
@@ -158,13 +188,10 @@ func runAnalyzeLocal(ctx context.Context, path string) error {
 		ui.Field("install script", filepath.Base(installScriptPath))
 	}
 
-	analysis, err := analyzeWith(ctx, aiProvider, pkgInfo, false)
+	analysis, err := analyzeWith(ctx, aiProvider, pkgInfo, out.asJSON)
 	if err != nil {
 		return fmt.Errorf("analysis failed: %w", err)
 	}
 
-	// Display detailed results
-	ui.RenderAnalysis(analysis, true)
-
-	return nil
+	return present(out, sourceLocal, &pkgInfo, analysis, false)
 }

--- a/internal/cmd/analyze.go
+++ b/internal/cmd/analyze.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -11,8 +10,6 @@ import (
 	"github.com/aaronsb/yay-friend/internal/aur"
 	"github.com/aaronsb/yay-friend/internal/cache"
 	"github.com/aaronsb/yay-friend/internal/config"
-	"github.com/aaronsb/yay-friend/internal/pkgbuild"
-	"github.com/aaronsb/yay-friend/internal/providers"
 	"github.com/aaronsb/yay-friend/internal/types"
 	"github.com/aaronsb/yay-friend/internal/ui"
 	"github.com/aaronsb/yay-friend/internal/yay"
@@ -62,32 +59,9 @@ func runAnalyze(ctx context.Context, packageName string) error {
 		return fmt.Errorf("yay not available: %w", err)
 	}
 
-	// Initialize providers
-	registry := providers.NewProviderRegistry()
-	claudeProvider := providers.NewClaudeProvider()
-	claudeProvider.SetConfig(cfg)
-	registry.Register("claude", claudeProvider)
-	registry.Register("qwen", providers.NewQwenProvider())
-	registry.Register("copilot", providers.NewCopilotProvider())
-	registry.Register("goose", providers.NewGooseProvider())
-
-	// Determine which provider to use
-	providerName := provider
-	if providerName == "" {
-		providerName = cfg.DefaultProvider
-	}
-	if providerName == "" {
-		providerName = "claude"
-	}
-
-	aiProvider, err := registry.Get(providerName)
+	aiProvider, err := resolveProvider(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("provider error: %w", err)
-	}
-
-	// Authenticate provider
-	if err := aiProvider.Authenticate(ctx); err != nil {
-		return fmt.Errorf("authentication failed for %s: %w", providerName, err)
+		return err
 	}
 
 	ui.Say("analyzing %s with %s", packageName, aiProvider.Name())
@@ -117,10 +91,10 @@ func runAnalyze(ctx context.Context, packageName string) error {
 	if cfg.Cache.Enabled && cacheManager != nil && pkgInfo.CommitHash != "" {
 		cachedAnalysis, cacheErr := cacheManager.GetCachedAnalysis(pkgInfo.Name, pkgInfo.CommitHash)
 		if cacheErr == nil {
-			ui.Say("using cached analysis (commit %s)", pkgInfo.CommitHash[:8])
+			ui.Say("using cached analysis (commit %s)", cache.ShortHash(pkgInfo.CommitHash))
 			analysis = cachedAnalysis
 		} else {
-			ui.Say("running fresh analysis (commit %s)", pkgInfo.CommitHash[:8])
+			ui.Say("running fresh analysis (commit %s)", cache.ShortHash(pkgInfo.CommitHash))
 			// Cache miss - continue to run AI analysis
 		}
 	}
@@ -130,14 +104,7 @@ func runAnalyze(ctx context.Context, packageName string) error {
 		// Display what we collected for analysis
 		ui.RenderCollected(pkgInfo)
 
-		// Analyze security with options (support --no-spinner)
-		// Check if provider supports options (for Claude)
-		if claudeProvider, ok := aiProvider.(*providers.ClaudeProvider); ok {
-			analysis, err = claudeProvider.AnalyzePKGBUILDWithOptions(ctx, *pkgInfo, noSpinner)
-		} else {
-			analysis, err = aiProvider.AnalyzePKGBUILD(ctx, *pkgInfo)
-		}
-
+		analysis, err = analyzeWith(ctx, aiProvider, *pkgInfo, false)
 		if err != nil {
 			return fmt.Errorf("analysis failed: %w", err)
 		}
@@ -164,81 +131,22 @@ func runAnalyzeLocal(ctx context.Context, path string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	// Initialize providers
-	registry := providers.NewProviderRegistry()
-	claudeProvider := providers.NewClaudeProvider()
-	claudeProvider.SetConfig(cfg)
-	registry.Register("claude", claudeProvider)
-	registry.Register("qwen", providers.NewQwenProvider())
-	registry.Register("copilot", providers.NewCopilotProvider())
-	registry.Register("goose", providers.NewGooseProvider())
-
-	// Determine which provider to use
-	providerName := provider
-	if providerName == "" {
-		providerName = cfg.DefaultProvider
-	}
-	if providerName == "" {
-		providerName = "claude"
-	}
-
-	aiProvider, err := registry.Get(providerName)
+	aiProvider, err := resolveProvider(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("provider error: %w", err)
+		return err
 	}
 
-	// Authenticate provider
-	if err := aiProvider.Authenticate(ctx); err != nil {
-		return fmt.Errorf("authentication failed for %s: %w", providerName, err)
-	}
-
-	// Determine if path is a file or directory
-	info, err := os.ReadFile(path)
-	var pkgbuildPath string
-	var pkgbuildContent []byte
-
-	if err == nil {
-		// Path is a file
-		pkgbuildPath = path
-		pkgbuildContent = info
-	} else {
-		// Try as directory
-		pkgbuildPath = filepath.Join(path, "PKGBUILD")
-		pkgbuildContent, err = os.ReadFile(pkgbuildPath)
-		if err != nil {
-			return fmt.Errorf("failed to read PKGBUILD: %w", err)
-		}
+	pkgbuildPath, err := resolvePKGBUILDPath(path)
+	if err != nil {
+		return err
 	}
 
 	ui.Say("analyzing local PKGBUILD %s with %s", pkgbuildPath, aiProvider.Name())
 	ui.Say("local PKGBUILD analysis is not cached")
 
-	// Parse basic package info from PKGBUILD
-	pkgInfo, vars := parseLocalPKGBUILD(string(pkgbuildContent), pkgbuildPath)
-
-	// Try to read additional files from the same directory
-	dir := filepath.Dir(pkgbuildPath)
-	pkgInfo.AdditionalFiles = make(map[string]string)
-
-	// Companion files are only discoverable when the PKGBUILD parses; an
-	// unparseable one still gets analyzed on its own source above.
-	var installScriptPath string
-	if vars != nil {
-		// Look for .install script
-		installScriptPath = findInstallScript(vars, dir)
-		if installScriptPath != "" {
-			if content, err := os.ReadFile(installScriptPath); err == nil {
-				pkgInfo.InstallScript = string(content)
-				pkgInfo.AdditionalFiles[filepath.Base(installScriptPath)] = string(content)
-			}
-		}
-
-		// Look for other referenced files (like shell scripts)
-		for _, file := range findAdditionalFiles(vars, dir) {
-			if content, err := os.ReadFile(filepath.Join(dir, file)); err == nil {
-				pkgInfo.AdditionalFiles[file] = string(content)
-			}
-		}
+	pkgInfo, installScriptPath, err := collectPackageTree(pkgbuildPath)
+	if err != nil {
+		return err
 	}
 
 	// Display what we collected for analysis
@@ -246,18 +154,11 @@ func runAnalyzeLocal(ctx context.Context, path string) error {
 
 	// RenderCollected already lists AdditionalFiles; only the install script
 	// needs calling out, because it is the part that runs as root.
-	if pkgInfo.InstallScript != "" {
+	if installScriptPath != "" {
 		ui.Field("install script", filepath.Base(installScriptPath))
 	}
 
-	// Analyze security
-	var analysis *types.SecurityAnalysis
-	if claudeProvider, ok := aiProvider.(*providers.ClaudeProvider); ok {
-		analysis, err = claudeProvider.AnalyzePKGBUILDWithOptions(ctx, pkgInfo, noSpinner)
-	} else {
-		analysis, err = aiProvider.AnalyzePKGBUILD(ctx, pkgInfo)
-	}
-
+	analysis, err := analyzeWith(ctx, aiProvider, pkgInfo, false)
 	if err != nil {
 		return fmt.Errorf("analysis failed: %w", err)
 	}
@@ -266,65 +167,4 @@ func runAnalyzeLocal(ctx context.Context, path string) error {
 	ui.RenderAnalysis(analysis, true)
 
 	return nil
-}
-
-// parseLocalPKGBUILD extracts basic package information from a PKGBUILD.
-// A PKGBUILD that will not parse still yields a usable PackageInfo: the raw
-// source is what the analyzer reads, and metadata is only there to orient the
-// user.
-// It returns the parsed variables alongside the info so companion-file discovery
-// does not have to parse the same source a second time; vars is nil when the
-// PKGBUILD could not be parsed.
-func parseLocalPKGBUILD(content string, path string) (types.PackageInfo, *pkgbuild.Vars) {
-	info := types.PackageInfo{
-		PKGBUILD:   content,
-		Maintainer: "Unknown",
-		// Defaults for local analysis
-		AURPageURL:     "Local PKGBUILD",
-		LastUpdated:    "Not available (local PKGBUILD)",
-		FirstSubmitted: "Not available (local PKGBUILD)",
-	}
-
-	vars, err := pkgbuild.Parse(content)
-	if err != nil {
-		ui.Warn("could not parse %s as shell (%v); analyzing raw source", path, err)
-		return info, nil
-	}
-
-	info.Name = vars.Name()
-	info.Version = vars.Str("pkgver")
-	info.Description = vars.Str("pkgdesc")
-	info.URL = vars.Str("url")
-	info.Maintainer = vars.Maintainer()
-	info.Dependencies = vars.Slice("depends")
-	info.MakeDepends = vars.Slice("makedepends")
-	info.OptDepends = vars.Slice("optdepends")
-
-	return info, vars
-}
-
-// findInstallScript returns the path to the .install script referenced by the
-// PKGBUILD, if that file exists alongside it.
-func findInstallScript(vars *pkgbuild.Vars, dir string) string {
-	name := vars.Install()
-	if name == "" {
-		return ""
-	}
-	path := filepath.Join(dir, name)
-	if _, err := os.Stat(path); err != nil {
-		return ""
-	}
-	return path
-}
-
-// findAdditionalFiles returns the source= entries that name a file present in
-// the PKGBUILD's directory, so their contents can be sent for analysis too.
-func findAdditionalFiles(vars *pkgbuild.Vars, dir string) []string {
-	var files []string
-	for _, name := range vars.LocalSources() {
-		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
-			files = append(files, name)
-		}
-	}
-	return files
 }

--- a/internal/cmd/analyze_json.go
+++ b/internal/cmd/analyze_json.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/ui"
+	"github.com/aaronsb/yay-friend/internal/version"
+)
+
+// Where the PKGBUILD under analysis came from.
+const (
+	sourceAUR   = "aur"
+	sourceLocal = "local"
+)
+
+// analysisReport is yay-friend's own machine-readable shape: the whole analysis,
+// plus the context it was produced in.
+//
+// It is deliberately not a grading contract. `yay-friend grade` emits
+// pacrat-grade/v1, which is a narrow answer to one question and drops
+// everything a host cannot act on; this carries the opposite bias — the
+// educational summary, the per-finding suggestions and notes, the
+// predictability score, the AUR community numbers — because a caller shaping
+// its own pipeline should not have to run the analysis twice to see what the
+// analyzer actually said.
+//
+// The entropy block is redundant with analysis.overall_entropy on purpose. The
+// analysis serializes the level as its integer, which is the honest storage
+// form and what the cache holds; a consumer writing a one-line jq filter wants
+// the name and the bounds without having to know the enum.
+type analysisReport struct {
+	YayFriendVersion string                  `json:"yay_friend_version"`
+	Source           string                  `json:"source"`
+	Cached           bool                    `json:"cached"`
+	Package          packageContext          `json:"package"`
+	Entropy          entropyReport           `json:"entropy"`
+	Analysis         *types.SecurityAnalysis `json:"analysis"`
+}
+
+type packageContext struct {
+	Name         string   `json:"name"`
+	Version      string   `json:"version,omitempty"`
+	CommitHash   string   `json:"commit_hash,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	URL          string   `json:"url,omitempty"`
+	Maintainer   string   `json:"maintainer,omitempty"`
+	AURPageURL   string   `json:"aur_page_url,omitempty"`
+	Votes        int      `json:"votes,omitempty"`
+	Popularity   float64  `json:"popularity,omitempty"`
+	Dependencies []string `json:"dependencies,omitempty"`
+	MakeDepends  []string `json:"make_depends,omitempty"`
+	PKGBUILDPath string   `json:"pkgbuild_path,omitempty"`
+	// Files names the companion files that were read and sent for analysis —
+	// the .install hook and any source= entry shipped beside the PKGBUILD.
+	Files []string `json:"files,omitempty"`
+}
+
+type entropyReport struct {
+	Value int    `json:"value"`
+	Name  string `json:"name"`
+	Min   int    `json:"min"`
+	Max   int    `json:"max"`
+}
+
+// present writes the finished analysis in whichever shape was asked for.
+func present(out analyzeOutput, source string, pkgInfo *types.PackageInfo, analysis *types.SecurityAnalysis, cached bool) error {
+	if !out.asJSON {
+		ui.RenderAnalysis(analysis, true)
+		return nil
+	}
+
+	report := analysisReport{
+		YayFriendVersion: version.Version,
+		Source:           source,
+		Cached:           cached,
+		Package: packageContext{
+			Name:         pkgInfo.Name,
+			Version:      pkgInfo.Version,
+			CommitHash:   pkgInfo.CommitHash,
+			Description:  pkgInfo.Description,
+			URL:          pkgInfo.URL,
+			Maintainer:   pkgInfo.Maintainer,
+			AURPageURL:   pkgInfo.AURPageURL,
+			Votes:        pkgInfo.Votes,
+			Popularity:   pkgInfo.Popularity,
+			Dependencies: pkgInfo.Dependencies,
+			MakeDepends:  pkgInfo.MakeDepends,
+			PKGBUILDPath: pkgInfo.PKGBUILDPath,
+			Files:        sortedKeys(pkgInfo.AdditionalFiles),
+		},
+		Entropy: entropyReport{
+			Value: int(analysis.OverallEntropy),
+			Name:  analysis.OverallEntropy.String(),
+			Min:   int(types.EntropyMinimal),
+			Max:   int(types.EntropyCritical),
+		},
+		Analysis: analysis,
+	}
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal analysis: %w", err)
+	}
+	_, err = fmt.Fprintf(out.out, "%s\n", data)
+	return err
+}
+
+// sortedKeys returns a map's keys in a stable order, so two runs over the same
+// tree produce byte-identical JSON.
+func sortedKeys(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	return slices.Sorted(maps.Keys(m))
+}

--- a/internal/cmd/analyze_json_test.go
+++ b/internal/cmd/analyze_json_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/ui"
+	"github.com/aaronsb/yay-friend/internal/version"
+)
+
+// analyzeHarness runs `yay-friend analyze --file` against a staged tree with a
+// provider that never calls a model, capturing the two streams apart.
+func analyzeHarness(t *testing.T) (*fakeProvider, string, gradeRunner) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", home+"/data")
+	t.Setenv("XDG_CONFIG_HOME", home+"/config")
+
+	fake := &fakeProvider{analysis: richAnalysis()}
+	restoreProvider := resolveProvider
+	resolveProvider = func(ctx context.Context, cfg *types.Config) (types.AIProvider, error) {
+		return fake, nil
+	}
+	out := ui.Out
+	t.Cleanup(func() {
+		resolveProvider = restoreProvider
+		ui.Out = out
+		fileFlag = ""
+	})
+
+	run := func(args ...string) (string, string, error) {
+		cmd := newAnalyzeCmd()
+		var stdout, stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		cmd.SetArgs(append([]string{}, args...))
+		err := cmd.Execute()
+		return stdout.String(), stderr.String(), err
+	}
+
+	return fake, writeTree(t, home), run
+}
+
+// richAnalysis carries the fields that exist in yay-friend's own shape and have
+// no home in a grading contract. They are the reason --json exists.
+func richAnalysis() *types.SecurityAnalysis {
+	a := cleanAnalysis()
+	a.PredictabilityScore = 0.92
+	a.EntropyFactors = []string{"single upstream source", "no install-time network"}
+	a.EducationalSummary = "Checksum-pinned sources are what a boring package looks like."
+	a.SecurityLessons = []string{"SKIP on a VCS source is normal", "read .install hooks first"}
+	a.Findings[0].Suggestion = "No action needed"
+	a.Findings[0].EntropyNotes = "expected, best-practice packaging"
+	return a
+}
+
+func TestAnalyzeJSONWritesOneCleanObjectToStdout(t *testing.T) {
+	_, tree, run := analyzeHarness(t)
+
+	stdout, stderr, err := run("--file", tree, "--json")
+	if err != nil {
+		t.Fatalf("analyze --json failed: %v\n%s", err, stderr)
+	}
+
+	if !strings.HasPrefix(stdout, "{") || !strings.HasSuffix(stdout, "}\n") {
+		t.Errorf("stdout is not exactly one JSON object:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "\x1b") {
+		t.Error("stdout carries ANSI escapes")
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(stdout))
+	var first json.RawMessage
+	if err := decoder.Decode(&first); err != nil {
+		t.Fatalf("stdout does not decode: %v", err)
+	}
+	if decoder.More() {
+		t.Error("stdout carries more than one JSON value")
+	}
+
+	// The narration is not gone, it moved. A human watching a --json run
+	// should still see what was collected.
+	if !strings.Contains(stderr, "collected for analysis") {
+		t.Errorf("progress should still reach stderr, got: %s", stderr)
+	}
+}
+
+func TestAnalyzeJSONCarriesTheWholeAnalysis(t *testing.T) {
+	_, tree, run := analyzeHarness(t)
+
+	stdout, stderr, err := run("--file", tree, "--json")
+	if err != nil {
+		t.Fatalf("analyze --json failed: %v\n%s", err, stderr)
+	}
+
+	var report analysisReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("stdout is not an analysis report: %v", err)
+	}
+
+	if report.YayFriendVersion != version.Version {
+		t.Errorf("yay_friend_version = %q, want %q", report.YayFriendVersion, version.Version)
+	}
+	if report.Source != sourceLocal {
+		t.Errorf("source = %q, want %q", report.Source, sourceLocal)
+	}
+	if report.Cached {
+		t.Error("a local analysis is not cached")
+	}
+	if report.Package.Name != "hello" || report.Package.Version != "2.12.1" {
+		t.Errorf("package = %+v, want hello 2.12.1", report.Package)
+	}
+	if got := report.Package.Files; len(got) != 2 || got[0] != "hello.install" || got[1] != "hello.sh" {
+		t.Errorf("files = %v, want the companion files that were read, sorted", got)
+	}
+
+	want := entropyReport{Value: int(types.EntropyLow), Name: "LOW", Min: 0, Max: 4}
+	if report.Entropy != want {
+		t.Errorf("entropy = %+v, want %+v", report.Entropy, want)
+	}
+
+	// The fields that make this shape richer than a grading, and the reason a
+	// caller might prefer it to `yay-friend grade`.
+	if report.Analysis.EducationalSummary == "" {
+		t.Error("the educational summary was dropped")
+	}
+	if len(report.Analysis.SecurityLessons) == 0 {
+		t.Error("the security lessons were dropped")
+	}
+	if report.Analysis.PredictabilityScore == 0 {
+		t.Error("the predictability score was dropped")
+	}
+	if report.Analysis.Findings[0].Suggestion == "" || report.Analysis.Findings[0].EntropyNotes == "" {
+		t.Error("per-finding suggestion and notes were dropped")
+	}
+}
+
+// The teaching contrast: this is yay-friend's own shape, not pacrat's. A host
+// that wants a grading runs `yay-friend grade`; a host that wants everything
+// runs this and shapes it itself.
+func TestAnalyzeJSONIsNotAGradingContract(t *testing.T) {
+	_, tree, run := analyzeHarness(t)
+
+	stdout, _, err := run("--file", tree, "--json")
+	if err != nil {
+		t.Fatalf("analyze --json failed: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(stdout), &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"contract", "grader", "subject", "grade", "scale"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("--json output declares %q; it must not pass for a grading", key)
+		}
+	}
+}
+
+func TestAnalyzeWithoutJSONRendersToStdout(t *testing.T) {
+	_, tree, run := analyzeHarness(t)
+
+	stdout, _, err := run("--file", tree)
+	if err != nil {
+		t.Fatalf("analyze failed: %v", err)
+	}
+	if strings.HasPrefix(strings.TrimSpace(stdout), "{") {
+		t.Error("without --json the analysis should be rendered, not marshalled")
+	}
+	if !strings.Contains(stdout, "no findings") && !strings.Contains(stdout, "source_analysis") {
+		t.Errorf("the rendered report is missing its findings:\n%s", stdout)
+	}
+}
+
+func TestAnalyzeJSONFailureWritesNothingToStdout(t *testing.T) {
+	fake, tree, run := analyzeHarness(t)
+	fake.err = errFakeProvider
+
+	stdout, _, err := run("--file", tree, "--json")
+	if err == nil {
+		t.Fatal("a failing provider must not produce a report")
+	}
+	if stdout != "" {
+		t.Errorf("stdout carried %q", stdout)
+	}
+}

--- a/internal/cmd/cache.go
+++ b/internal/cmd/cache.go
@@ -195,12 +195,12 @@ func runCacheShow(ctx context.Context, packageName string) error {
 	for _, commitHash := range versions {
 		analysis, err := cacheManager.GetCachedAnalysis(packageName, commitHash)
 		if err != nil {
-			ui.Bullet("%s (error reading cache)", commitHash[:8])
+			ui.Bullet("%s (error reading cache)", cache.ShortHash(commitHash))
 			continue
 		}
 
 		ui.Blank()
-		fmt.Printf("  %s  %s\n", ui.Mark(analysis.OverallLevel), commitHash[:8])
+		fmt.Printf("  %s  %s\n", ui.Mark(analysis.OverallLevel), cache.ShortHash(commitHash))
 		ui.Field("provider", analysis.Provider)
 		ui.Field("analyzed", humanize.Time(analysis.AnalyzedAt))
 		if analysis.Summary != "" {

--- a/internal/cmd/grade.go
+++ b/internal/cmd/grade.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aaronsb/yay-friend/internal/cache"
+	"github.com/aaronsb/yay-friend/internal/config"
+	"github.com/aaronsb/yay-friend/internal/grade"
+	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/ui"
+)
+
+// subject is what a grading is about: a package name, the staged tree holding
+// the bytes to read, and the commit those bytes are at.
+type subject struct {
+	pkg    string
+	tree   string
+	commit string
+}
+
+func newGradeCmd() *cobra.Command {
+	var flags subject
+
+	cmd := &cobra.Command{
+		Use:   "grade",
+		Short: "Emit a pacrat-grade/v1 grading of a staged package tree",
+		Long: `Grade a staged package tree and write a pacrat-grade/v1 report to stdout.
+
+This is the grader interface of pacrat (https://github.com/aaronsb/pacrat), which
+gates AUR updates on a grade from any program that speaks the contract. The
+subject arrives in the environment, so registering yay-friend is one line:
+
+    [[graders]]
+    name = "yay-friend"
+    cmd = "yay-friend grade"
+    timeout_s = 600
+    scale = { min = 0, max = 4 }
+
+The tree is what gets read — the PKGBUILD pacrat staged, its .install hook and
+any file shipped beside it — not a fresh fetch of whatever the AUR is serving
+now. The result is filed in yay-friend's own cache under the commit, so a second
+ask about the same tree replays instead of calling a model again.
+
+stdout carries the grading and nothing else. Any failure is a nonzero exit with
+the reason on stderr and no JSON at all: pacrat reads that as UNGRADED, which
+holds, and a half-report is worse than none.
+
+The grade is how alarming the tree is, on 0-4, and only that. PROCEED / WARN /
+BLOCK is pacrat's to derive from it with the host's own thresholds.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// stdout is reserved for the grading from here on.
+			ui.Out = cmd.ErrOrStderr()
+
+			return withUsage(cmd, func() error {
+				return runGrade(cmd.Context(), flags, cmd.OutOrStdout())
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.pkg, "package", "", "Package name (default $PACRAT_PACKAGE)")
+	cmd.Flags().StringVar(&flags.tree, "tree", "", "Directory holding the PKGBUILD to grade (default $PACRAT_TREE)")
+	cmd.Flags().StringVar(&flags.commit, "commit", "", "Commit the tree is at, as a hex object id (default $PACRAT_COMMIT)")
+
+	return cmd
+}
+
+func runGrade(ctx context.Context, flags subject, out io.Writer) error {
+	subj, err := resolveSubject(flags)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// The cache is keyed by the commit in lowercase, because git and yay-friend
+	// both spell object ids that way; an uppercase request would otherwise miss
+	// an entry sitting right there and spend a real analysis discovering it. The
+	// grading still reports the commit as pacrat spelled it.
+	key := strings.ToLower(subj.commit)
+
+	var cacheManager *cache.CacheManager
+	if cfg.Cache.Enabled {
+		cacheManager, err = cache.NewCacheManager()
+		if err != nil {
+			ui.Warn("could not initialize cache: %v", err)
+			cacheManager = nil
+		}
+	}
+
+	var analysis *types.SecurityAnalysis
+	cached := false
+	if cacheManager != nil {
+		if hit, cacheErr := cacheManager.GetCachedAnalysis(subj.pkg, key); cacheErr == nil {
+			ui.Say("replaying cached analysis for %s@%s", subj.pkg, cache.ShortHash(subj.commit))
+			analysis, cached = hit, true
+		}
+	}
+
+	if analysis == nil {
+		pkgInfo, err := readSubjectTree(subj)
+		if err != nil {
+			return err
+		}
+
+		// Only on the miss path: a hit is a file read, and demanding a
+		// configured, reachable provider for it would fail a question that was
+		// already answered.
+		aiProvider, err := resolveProvider(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		ui.Say("analyzing %s@%s with %s", subj.pkg, cache.ShortHash(subj.commit), aiProvider.Name())
+
+		analysis, err = analyzeWith(ctx, aiProvider, pkgInfo, true)
+		if err != nil {
+			return fmt.Errorf("analysis failed: %w", err)
+		}
+
+		if cacheManager != nil {
+			if cacheErr := cacheManager.SaveAnalysis(subj.pkg, key, analysis); cacheErr != nil {
+				ui.Warn("could not save analysis to cache: %v", cacheErr)
+			}
+		}
+	}
+
+	report, err := grade.FromAnalysis(grade.Subject{
+		Package: subj.pkg,
+		Commit:  subj.commit,
+		Version: treeVersion(subj.tree),
+	}, analysis, cached)
+	if err != nil {
+		return err
+	}
+
+	// Marshalled whole before a byte reaches stdout: an encoder writing
+	// straight to the pipe and failing partway would leave half a grading
+	// there, and half a grading parses as garbage rather than as the failure it
+	// is.
+	data, err := json.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("failed to marshal grading: %w", err)
+	}
+	_, err = fmt.Fprintf(out, "%s\n", data)
+	return err
+}
+
+// resolveSubject takes the subject from the flags, falling back to the
+// PACRAT_* environment variables pacrat exports for every grader run. Flags win
+// when both are present, so a human can drive the same command by hand.
+func resolveSubject(flags subject) (subject, error) {
+	subj := subject{
+		pkg:    firstNonEmpty(flags.pkg, os.Getenv("PACRAT_PACKAGE")),
+		tree:   firstNonEmpty(flags.tree, os.Getenv("PACRAT_TREE")),
+		commit: firstNonEmpty(flags.commit, os.Getenv("PACRAT_COMMIT")),
+	}
+
+	for _, missing := range []struct{ value, flag, env string }{
+		{subj.pkg, "--package", "PACRAT_PACKAGE"},
+		{subj.tree, "--tree", "PACRAT_TREE"},
+		{subj.commit, "--commit", "PACRAT_COMMIT"},
+	} {
+		if missing.value == "" {
+			return subject{}, usageError{fmt.Errorf("no subject to grade: %s is required, or set %s",
+				missing.flag, missing.env)}
+		}
+	}
+
+	// pacrat validates these too, but a grader that only works when its caller
+	// is careful is a grader that breaks the first time it is run by hand. Both
+	// become path components in the cache.
+	if err := validatePackageName(subj.pkg); err != nil {
+		return subject{}, usageError{err}
+	}
+	if err := validateCommit(subj.commit); err != nil {
+		return subject{}, usageError{err}
+	}
+
+	return subj, nil
+}
+
+func validatePackageName(name string) error {
+	if strings.HasPrefix(name, "-") || strings.HasPrefix(name, ".") {
+		return fmt.Errorf("%q is not a package name", name)
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '@' || r == '.' || r == '_' || r == '+' || r == '-':
+		default:
+			return fmt.Errorf("%q is not a package name", name)
+		}
+	}
+	return nil
+}
+
+func validateCommit(commit string) error {
+	for _, r := range commit {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return fmt.Errorf("%q is not a commit hash", commit)
+		}
+	}
+	// Seven is the shortest prefix git will abbreviate to, and the shortest
+	// pacrat compares. Sixty-four admits the SHA-256 object ids git is moving
+	// toward. Bounded at all so an impossible commit is refused before the miss
+	// path spends a model call discovering that no such tree exists.
+	if len(commit) < 7 {
+		return fmt.Errorf("commit %q is too short to name a tree", commit)
+	}
+	if len(commit) > 64 {
+		return fmt.Errorf("commit %q is longer than any git object id", commit)
+	}
+	return nil
+}
+
+// readSubjectTree collects the bytes under judgement: the PKGBUILD pacrat
+// staged and every companion file it references.
+//
+// The name and commit come from the subject rather than from the tree. pacrat
+// discards a grading whose subject is not the one it asked about, and a
+// PKGBUILD is untrusted input — letting it name itself would be letting it pick
+// which cache entry the grading lands in.
+func readSubjectTree(subj subject) (types.PackageInfo, error) {
+	info, err := os.Stat(subj.tree)
+	if err != nil {
+		return types.PackageInfo{}, fmt.Errorf("cannot read tree %s: %w", subj.tree, err)
+	}
+	if !info.IsDir() {
+		return types.PackageInfo{}, fmt.Errorf("tree %s is not a directory", subj.tree)
+	}
+
+	pkgInfo, _, err := collectPackageTree(filepath.Join(subj.tree, "PKGBUILD"))
+	if err != nil {
+		return types.PackageInfo{}, err
+	}
+
+	pkgInfo.Name = subj.pkg
+	pkgInfo.CommitHash = subj.commit
+	if v := treeVersion(subj.tree); v != "" {
+		pkgInfo.Version = v
+	}
+	return pkgInfo, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/cmd/grade.go
+++ b/internal/cmd/grade.go
@@ -102,10 +102,14 @@ func runGrade(ctx context.Context, flags subject, out io.Writer) error {
 
 	var analysis *types.SecurityAnalysis
 	cached := false
+	producedBy := ""
 	if cacheManager != nil {
-		if hit, cacheErr := cacheManager.GetCachedAnalysis(subj.pkg, key); cacheErr == nil {
+		if entry, cacheErr := cacheManager.GetCachedEntry(subj.pkg, key); cacheErr == nil {
 			ui.Say("replaying cached analysis for %s@%s", subj.pkg, cache.ShortHash(subj.commit))
-			analysis, cached = hit, true
+			analysis, cached = entry.Analysis, true
+			// The version that produced the analysis, not the one replaying
+			// it — the adapter reported the same thing under the same key.
+			producedBy = entry.CacheMetadata.YayFriendVersion
 		}
 	}
 
@@ -140,7 +144,7 @@ func runGrade(ctx context.Context, flags subject, out io.Writer) error {
 		Package: subj.pkg,
 		Commit:  subj.commit,
 		Version: treeVersion(subj.tree),
-	}, analysis, cached)
+	}, analysis, cached, producedBy)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/grade_test.go
+++ b/internal/cmd/grade_test.go
@@ -1,0 +1,515 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aaronsb/yay-friend/internal/cache"
+	"github.com/aaronsb/yay-friend/internal/grade"
+	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/ui"
+)
+
+const (
+	testCommit  = "51cec6333515471681ec8aa00943145d420311fa"
+	otherCommit = "a7c5e8780f8ab4249a1f5d90e9a910ff01c9f99f"
+)
+
+// fakeProvider stands in for an AI provider and counts how often it was asked
+// to analyze anything. Nothing in this file may reach a real model: a test that
+// costs money is a test nobody runs.
+type fakeProvider struct {
+	calls    int
+	seen     types.PackageInfo
+	analysis *types.SecurityAnalysis
+	err      error
+}
+
+func (f *fakeProvider) Name() string          { return "fake" }
+func (f *fakeProvider) IsAuthenticated() bool { return true }
+
+func (f *fakeProvider) Authenticate(ctx context.Context) error { return nil }
+
+func (f *fakeProvider) AnalyzePKGBUILD(ctx context.Context, pkgInfo types.PackageInfo) (*types.SecurityAnalysis, error) {
+	f.calls++
+	f.seen = pkgInfo
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.analysis, nil
+}
+
+func (f *fakeProvider) GetCapabilities() types.ProviderCapabilities {
+	return types.ProviderCapabilities{SupportsCodeAnalysis: true}
+}
+
+func cleanAnalysis() *types.SecurityAnalysis {
+	return &types.SecurityAnalysis{
+		PackageName:    "hello",
+		OverallEntropy: types.EntropyLow,
+		OverallLevel:   types.EntropyLow,
+		Findings: []types.SecurityFinding{{
+			Type:        "source_analysis",
+			Entropy:     types.EntropyMinimal,
+			Description: "every source is checksum-pinned",
+			LineNumber:  7,
+		}},
+		Summary:        "Clean package.",
+		Recommendation: "PROCEED",
+		Provider:       "fake",
+	}
+}
+
+const testPKGBUILD = `# Maintainer: someone <someone@example.invalid>
+pkgname=hello
+pkgver=2.12.1
+pkgrel=1
+pkgdesc='Prints a greeting'
+arch=('any')
+install=hello.install
+source=('hello.sh')
+sha256sums=('SKIP')
+
+package() {
+  install -Dm755 "$srcdir/hello.sh" "$pkgdir/usr/bin/hello"
+}
+`
+
+// writeTree stages the kind of directory pacrat hands a grader: a PKGBUILD, the
+// .SRCINFO the version is read from, and the companion files the PKGBUILD
+// references.
+func writeTree(t *testing.T, dir string) string {
+	t.Helper()
+	tree := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(tree, 0755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"PKGBUILD":      testPKGBUILD,
+		".SRCINFO":      "pkgbase = hello\n\tpkgver = 2.12.1\n\tpkgrel = 1\n\npkgname = hello\n",
+		"hello.install": "post_install() {\n  echo hello\n}\n",
+		"hello.sh":      "#!/bin/sh\necho hello\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(tree, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return tree
+}
+
+// runGradeCmd runs `yay-friend grade` with the two streams captured apart:
+// stdout must be the grading and nothing else, so a diagnostic leaking into it
+// has to be something a test can see.
+type gradeRunner func(args ...string) (stdout, stderr string, err error)
+
+func gradeHarness(t *testing.T) (*fakeProvider, string, gradeRunner) {
+	t.Helper()
+
+	// Every XDG root moves into the test's own directory: the real cache and
+	// the real config are never read and never written.
+	home := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("PACRAT_PACKAGE", "")
+	t.Setenv("PACRAT_TREE", "")
+	t.Setenv("PACRAT_COMMIT", "")
+
+	fake := &fakeProvider{analysis: cleanAnalysis()}
+	restore := resolveProvider
+	resolveProvider = func(ctx context.Context, cfg *types.Config) (types.AIProvider, error) {
+		return fake, nil
+	}
+	out := ui.Out
+	t.Cleanup(func() {
+		resolveProvider = restore
+		ui.Out = out
+	})
+
+	run := func(args ...string) (string, string, error) {
+		cmd := newGradeCmd()
+		var stdout, stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		// Non-nil even when empty: cobra falls back to os.Args for a nil arg
+		// slice, and os.Args under `go test` is full of -test.* flags.
+		cmd.SetArgs(append([]string{}, args...))
+		err := cmd.Execute()
+		return stdout.String(), stderr.String(), err
+	}
+
+	return fake, writeTree(t, home), run
+}
+
+func decodeGrading(t *testing.T, stdout string) grade.Report {
+	t.Helper()
+	var report grade.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("stdout is not a grading: %v\n%s", err, stdout)
+	}
+	if report.Contract != grade.Contract {
+		t.Errorf("contract = %q, want %q", report.Contract, grade.Contract)
+	}
+	return report
+}
+
+func TestGradeTakesItsSubjectFromTheEnvironment(t *testing.T) {
+	_, tree, run := gradeHarness(t)
+	t.Setenv("PACRAT_PACKAGE", "hello")
+	t.Setenv("PACRAT_TREE", tree)
+	t.Setenv("PACRAT_COMMIT", testCommit)
+
+	stdout, stderr, err := run()
+	if err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+
+	report := decodeGrading(t, stdout)
+	want := grade.Subject{Package: "hello", Commit: testCommit, Version: "2.12.1-1"}
+	if report.Subject != want {
+		t.Errorf("subject = %+v, want %+v", report.Subject, want)
+	}
+}
+
+func TestGradeFlagsBeatTheEnvironment(t *testing.T) {
+	_, tree, run := gradeHarness(t)
+	t.Setenv("PACRAT_PACKAGE", "from-env")
+	t.Setenv("PACRAT_TREE", "/nonexistent")
+	t.Setenv("PACRAT_COMMIT", otherCommit)
+
+	stdout, stderr, err := run("--package", "hello", "--tree", tree, "--commit", testCommit)
+	if err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+
+	report := decodeGrading(t, stdout)
+	if report.Subject.Package != "hello" || report.Subject.Commit != testCommit {
+		t.Errorf("subject = %+v, want the flags to win", report.Subject)
+	}
+}
+
+// One half from the environment, the other from a flag: the two sources are
+// merged per field, not chosen between.
+func TestGradeMixesFlagsAndEnvironmentPerField(t *testing.T) {
+	_, tree, run := gradeHarness(t)
+	t.Setenv("PACRAT_PACKAGE", "hello")
+	t.Setenv("PACRAT_TREE", tree)
+
+	stdout, stderr, err := run("--commit", testCommit)
+	if err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+	report := decodeGrading(t, stdout)
+	if report.Subject.Package != "hello" || report.Subject.Commit != testCommit {
+		t.Errorf("subject = %+v, want hello@%s", report.Subject, testCommit)
+	}
+}
+
+func TestGradeWithoutASubjectIsAUsageError(t *testing.T) {
+	_, tree, run := gradeHarness(t)
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"nothing at all", nil, "PACRAT_PACKAGE"},
+		{"no tree", []string{"--package", "hello", "--commit", testCommit}, "PACRAT_TREE"},
+		{"no commit", []string{"--package", "hello", "--tree", tree}, "PACRAT_COMMIT"},
+		{"not a package name", []string{"--package", "../etc", "--tree", tree, "--commit", testCommit}, "not a package name"},
+		{"not hex", []string{"--package", "hello", "--tree", tree, "--commit", "nothex"}, "not a commit hash"},
+		{"too short", []string{"--package", "hello", "--tree", tree, "--commit", "abc123"}, "too short"},
+		{"too long", []string{"--package", "hello", "--tree", tree, "--commit", strings.Repeat("0", 65)}, "longer than"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := run(tc.args...)
+			if err == nil {
+				t.Fatalf("expected a refusal, got: %s", stdout)
+			}
+			if stdout != "" {
+				t.Errorf("a refusal must write nothing to stdout, got: %s", stdout)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+			if !strings.Contains(stderr, "Usage:") {
+				t.Errorf("a usage error should print usage, got: %s", stderr)
+			}
+		})
+	}
+}
+
+// The cache hit is the path pacrat's update loop actually takes, and it must
+// not need a provider at all: a hit is a file read, and demanding a reachable
+// model for it would fail a question that was already answered.
+func TestGradeCacheHitDoesNotCallTheProvider(t *testing.T) {
+	fake, tree, run := gradeHarness(t)
+
+	cacheManager, err := cache.NewCacheManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seeded := cleanAnalysis()
+	seeded.OverallEntropy = types.EntropyHigh
+	if err := cacheManager.SaveAnalysis("hello", testCommit, seeded); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := run("--package", "hello", "--tree", tree, "--commit", testCommit)
+	if err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+
+	if fake.calls != 0 {
+		t.Errorf("provider was called %d times on a cache hit", fake.calls)
+	}
+	report := decodeGrading(t, stdout)
+	if report.Grade != int(types.EntropyHigh) {
+		t.Errorf("grade = %d, want the cached %d", report.Grade, types.EntropyHigh)
+	}
+	if !report.Meta.Cached {
+		t.Error("meta.cached should be true for a replayed grading")
+	}
+}
+
+func TestGradeCacheMissAnalysesOnceAndReplaysAfter(t *testing.T) {
+	fake, tree, run := gradeHarness(t)
+	args := []string{"--package", "hello", "--tree", tree, "--commit", testCommit}
+
+	stdout, stderr, err := run(args...)
+	if err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("provider was called %d times, want 1", fake.calls)
+	}
+	if report := decodeGrading(t, stdout); report.Meta.Cached {
+		t.Error("meta.cached should be false for a freshly analyzed grading")
+	}
+
+	// Filed under the commit, in lowercase, where the next ask will find it.
+	entry := filepath.Join(os.Getenv("XDG_DATA_HOME"), "yay-friend", "cache", "hello", testCommit+".json")
+	if _, err := os.Stat(entry); err != nil {
+		t.Errorf("the analysis was not cached at %s: %v", entry, err)
+	}
+
+	stdout, stderr, err = run(args...)
+	if err != nil {
+		t.Fatalf("second grade failed: %v\n%s", err, stderr)
+	}
+	if fake.calls != 1 {
+		t.Errorf("provider was called %d times over two runs, want 1", fake.calls)
+	}
+	if report := decodeGrading(t, stdout); !report.Meta.Cached {
+		t.Error("the second run should replay the cached grading")
+	}
+}
+
+// Hex case is not meaningful, and pacrat compares commits case-insensitively.
+// An uppercase request must find the entry sitting right there rather than
+// spending a model call discovering it.
+func TestGradeUppercaseCommitStillHitsTheCache(t *testing.T) {
+	fake, tree, run := gradeHarness(t)
+
+	cacheManager, err := cache.NewCacheManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cacheManager.SaveAnalysis("hello", testCommit, cleanAnalysis()); err != nil {
+		t.Fatal(err)
+	}
+
+	upper := strings.ToUpper(testCommit)
+	stdout, stderr, err := run("--package", "hello", "--tree", tree, "--commit", upper)
+	if err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+	if fake.calls != 0 {
+		t.Errorf("an uppercase request ran an analysis instead of hitting the cache")
+	}
+	if report := decodeGrading(t, stdout); report.Subject.Commit != upper {
+		t.Errorf("subject.commit = %q, want the commit as it was asked for", report.Subject.Commit)
+	}
+}
+
+// The tree is the bytes under judgement: the PKGBUILD pacrat staged, plus the
+// companion files it references — not a fresh fetch of whatever the AUR is
+// serving now.
+func TestGradeReadsTheTreeItWasHanded(t *testing.T) {
+	fake, tree, run := gradeHarness(t)
+
+	if _, stderr, err := run("--package", "hello", "--tree", tree, "--commit", testCommit); err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+
+	if fake.seen.PKGBUILD != testPKGBUILD {
+		t.Error("the analyzer did not receive the staged PKGBUILD")
+	}
+	if !strings.Contains(fake.seen.InstallScript, "post_install") {
+		t.Errorf("the .install hook was not collected: %q", fake.seen.InstallScript)
+	}
+	if _, ok := fake.seen.AdditionalFiles["hello.sh"]; !ok {
+		t.Errorf("a local source= file was not collected: %v", fake.seen.AdditionalFiles)
+	}
+	if fake.seen.CommitHash != testCommit {
+		t.Errorf("commit = %q, want the one we were asked about", fake.seen.CommitHash)
+	}
+}
+
+// The subject's package name wins over the tree's. A PKGBUILD is untrusted
+// input, and letting it name itself would be letting it pick which cache entry
+// the grading lands in.
+func TestGradeNamesTheSubjectPacratAskedAbout(t *testing.T) {
+	fake, tree, run := gradeHarness(t)
+	if err := os.WriteFile(filepath.Join(tree, "PKGBUILD"),
+		[]byte("pkgname=somethingelse\npkgver=1\npkgrel=1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := run("--package", "hello", "--tree", tree, "--commit", testCommit)
+	if err != nil {
+		t.Fatalf("grade failed: %v\n%s", err, stderr)
+	}
+	if fake.seen.Name != "hello" {
+		t.Errorf("the analyzer was told the package is %q", fake.seen.Name)
+	}
+	if report := decodeGrading(t, stdout); report.Subject.Package != "hello" {
+		t.Errorf("subject.package = %q, want hello", report.Subject.Package)
+	}
+}
+
+// Any failure is a nonzero exit with the reason on stderr and no JSON at all.
+// pacrat reads a failed grader as UNGRADED, which holds; a half-report is worse
+// than none.
+func TestGradeFailuresWriteNothingToStdout(t *testing.T) {
+	t.Run("provider error", func(t *testing.T) {
+		fake, tree, run := gradeHarness(t)
+		fake.err = errFakeProvider
+
+		stdout, _, err := run("--package", "hello", "--tree", tree, "--commit", testCommit)
+		if err == nil {
+			t.Fatal("a failing provider must not produce a grading")
+		}
+		if stdout != "" {
+			t.Errorf("stdout carried %q", stdout)
+		}
+	})
+
+	t.Run("no provider configured", func(t *testing.T) {
+		_, tree, run := gradeHarness(t)
+		resolveProvider = func(ctx context.Context, cfg *types.Config) (types.AIProvider, error) {
+			return nil, errFakeProvider
+		}
+
+		stdout, _, err := run("--package", "hello", "--tree", tree, "--commit", testCommit)
+		if err == nil {
+			t.Fatal("an unavailable provider must not produce a grading")
+		}
+		if stdout != "" {
+			t.Errorf("stdout carried %q", stdout)
+		}
+	})
+
+	t.Run("unreadable tree", func(t *testing.T) {
+		_, _, run := gradeHarness(t)
+
+		stdout, _, err := run("--package", "hello", "--tree", "/nonexistent/tree", "--commit", testCommit)
+		if err == nil {
+			t.Fatal("an unreadable tree must not produce a grading")
+		}
+		if stdout != "" {
+			t.Errorf("stdout carried %q", stdout)
+		}
+	})
+
+	t.Run("tree with no PKGBUILD", func(t *testing.T) {
+		_, _, run := gradeHarness(t)
+		empty := t.TempDir()
+
+		stdout, _, err := run("--package", "hello", "--tree", empty, "--commit", testCommit)
+		if err == nil {
+			t.Fatal("a tree with no PKGBUILD must not produce a grading")
+		}
+		if stdout != "" {
+			t.Errorf("stdout carried %q", stdout)
+		}
+	})
+
+	t.Run("an entropy off the scale", func(t *testing.T) {
+		fake, tree, run := gradeHarness(t)
+		fake.analysis.OverallEntropy = 70
+
+		stdout, _, err := run("--package", "hello", "--tree", tree, "--commit", testCommit)
+		if err == nil {
+			t.Fatal("an unplaceable entropy must be refused, not clamped")
+		}
+		if stdout != "" {
+			t.Errorf("stdout carried %q", stdout)
+		}
+	})
+}
+
+// pacrat's setup interview probes exactly this to decide whether the installed
+// binary speaks the contract natively.
+func TestGradeHelpExitsZero(t *testing.T) {
+	_, _, run := gradeHarness(t)
+
+	stdout, stderr, err := run("--help")
+	if err != nil {
+		t.Fatalf("grade --help must exit 0, got %v", err)
+	}
+	if !strings.Contains(stdout+stderr, "pacrat-grade/v1") {
+		t.Error("the help should name the contract it speaks")
+	}
+}
+
+func TestGradeIsRegisteredOnTheRootCommand(t *testing.T) {
+	var found *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "grade" {
+			found = c
+		}
+	}
+	if found == nil {
+		t.Fatal("grade is not a subcommand of yay-friend")
+	}
+}
+
+func TestGradeStdoutIsOneJSONObjectAndNothingElse(t *testing.T) {
+	_, tree, run := gradeHarness(t)
+
+	stdout, _, err := run("--package", "hello", "--tree", tree, "--commit", testCommit)
+	if err != nil {
+		t.Fatalf("grade failed: %v", err)
+	}
+	if !strings.HasPrefix(stdout, "{") || !strings.HasSuffix(stdout, "}\n") {
+		t.Errorf("stdout is not exactly one JSON object:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "\x1b") {
+		t.Error("stdout carries ANSI escapes")
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(stdout))
+	var first json.RawMessage
+	if err := decoder.Decode(&first); err != nil {
+		t.Fatalf("stdout does not decode: %v", err)
+	}
+	if decoder.More() {
+		t.Error("stdout carries more than one JSON value")
+	}
+}
+
+var errFakeProvider = errorString("provider unavailable")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }

--- a/internal/cmd/grade_test.go
+++ b/internal/cmd/grade_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -513,3 +515,35 @@ var errFakeProvider = errorString("provider unavailable")
 type errorString string
 
 func (e errorString) Error() string { return string(e) }
+
+// A FIFO named PKGBUILD used to hang grade in open() forever — past SIGTERM,
+// since main's signal context replaces die-on-signal with a cancel no file
+// read observes. readRegular refuses anything irregular before opening it.
+func TestAFIFONamedPKGBUILDIsRefusedNotHung(t *testing.T) {
+	_, tree, run := gradeHarness(t)
+	if err := os.Remove(filepath.Join(tree, "PKGBUILD")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(tree, "PKGBUILD"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var stdout string
+	var err error
+	go func() {
+		stdout, _, err = run("--package", "hello", "--tree", tree, "--commit", testCommit)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("grade hung on a FIFO PKGBUILD")
+	}
+	if err == nil {
+		t.Fatal("a FIFO PKGBUILD graded successfully")
+	}
+	if stdout != "" {
+		t.Errorf("a failure wrote to stdout: %q", stdout)
+	}
+}

--- a/internal/cmd/provider_resolve.go
+++ b/internal/cmd/provider_resolve.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aaronsb/yay-friend/internal/providers"
+	"github.com/aaronsb/yay-friend/internal/types"
+)
+
+// resolveProvider returns the AI provider named by --provider, else the one in
+// config, else claude — registered, authenticated, and ready to analyze.
+//
+// It is a variable so a test can substitute a provider that never calls a model.
+// Nothing in production assigns it: the install path, the analyze path and the
+// grade path all went through their own copy of this block before, and the four
+// copies had already started to drift.
+var resolveProvider = defaultResolveProvider
+
+func defaultResolveProvider(ctx context.Context, cfg *types.Config) (types.AIProvider, error) {
+	registry := providers.NewProviderRegistry()
+	claudeProvider := providers.NewClaudeProvider()
+	claudeProvider.SetConfig(cfg)
+	registry.Register("claude", claudeProvider)
+	registry.Register("qwen", providers.NewQwenProvider())
+	registry.Register("copilot", providers.NewCopilotProvider())
+	registry.Register("goose", providers.NewGooseProvider())
+
+	name := provider
+	if name == "" {
+		name = cfg.DefaultProvider
+	}
+	if name == "" {
+		name = "claude"
+	}
+
+	aiProvider, err := registry.Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("provider error: %w", err)
+	}
+
+	if err := aiProvider.Authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("authentication failed for %s: %w", name, err)
+	}
+
+	return aiProvider, nil
+}
+
+// analyzeWith runs an analysis, taking Claude's options-aware entry point when
+// the provider is Claude so that --no-spinner is honored.
+//
+// quiet forces the non-streaming path regardless of --no-spinner. Machine
+// output (grade, analyze --json) sets it: the streaming renderer repaints its
+// progress line with carriage returns and ANSI erases, and a caller reading
+// stderr for a diagnostic should not have to read past that.
+func analyzeWith(ctx context.Context, aiProvider types.AIProvider, pkgInfo types.PackageInfo, quiet bool) (*types.SecurityAnalysis, error) {
+	if claudeProvider, ok := aiProvider.(*providers.ClaudeProvider); ok {
+		return claudeProvider.AnalyzePKGBUILDWithOptions(ctx, pkgInfo, quiet || noSpinner)
+	}
+	return aiProvider.AnalyzePKGBUILD(ctx, pkgInfo)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aaronsb/yay-friend/internal/aur"
 	"github.com/aaronsb/yay-friend/internal/cache"
 	"github.com/aaronsb/yay-friend/internal/config"
-	"github.com/aaronsb/yay-friend/internal/providers"
 	"github.com/aaronsb/yay-friend/internal/types"
 	"github.com/aaronsb/yay-friend/internal/ui"
 	"github.com/aaronsb/yay-friend/internal/yay"
@@ -176,32 +175,9 @@ func runInstall(ctx context.Context, args []string) error {
 	// Update operation with final package list
 	operation.Packages = finalPackages
 
-	// Initialize providers
-	registry := providers.NewProviderRegistry()
-	claudeProvider := providers.NewClaudeProvider()
-	claudeProvider.SetConfig(cfg)
-	registry.Register("claude", claudeProvider)
-	registry.Register("qwen", providers.NewQwenProvider())
-	registry.Register("copilot", providers.NewCopilotProvider())
-	registry.Register("goose", providers.NewGooseProvider())
-
-	// Determine which provider to use
-	providerName := provider
-	if providerName == "" {
-		providerName = cfg.DefaultProvider
-	}
-	if providerName == "" {
-		providerName = "claude" // Default fallback
-	}
-
-	aiProvider, err := registry.Get(providerName)
+	aiProvider, err := resolveProvider(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("provider error: %w", err)
-	}
-
-	// Authenticate provider
-	if err := aiProvider.Authenticate(ctx); err != nil {
-		return fmt.Errorf("authentication failed for %s: %w", providerName, err)
+		return err
 	}
 
 	// Analyze packages
@@ -278,10 +254,10 @@ func analyzeAndDecide(ctx context.Context, yayClient *yay.YayClient, provider ty
 	if cfg.Cache.Enabled && cacheManager != nil && pkgInfo.CommitHash != "" {
 		cachedAnalysis, cacheErr := cacheManager.GetCachedAnalysis(pkgInfo.Name, pkgInfo.CommitHash)
 		if cacheErr == nil {
-			ui.Say("using cached analysis (commit %s)", pkgInfo.CommitHash[:8])
+			ui.Say("using cached analysis (commit %s)", cache.ShortHash(pkgInfo.CommitHash))
 			analysis = cachedAnalysis
 		} else {
-			ui.Say("running fresh analysis (commit %s)", pkgInfo.CommitHash[:8])
+			ui.Say("running fresh analysis (commit %s)", cache.ShortHash(pkgInfo.CommitHash))
 			// Cache miss - continue to run AI analysis
 		}
 	}
@@ -292,13 +268,7 @@ func analyzeAndDecide(ctx context.Context, yayClient *yay.YayClient, provider ty
 		ui.RenderCollected(pkgInfo)
 
 		// Analyze security with enriched context
-		// Check if provider supports options (for Claude)
-		if claudeProvider, ok := provider.(*providers.ClaudeProvider); ok {
-			analysis, err = claudeProvider.AnalyzePKGBUILDWithOptions(ctx, *pkgInfo, noSpinner)
-		} else {
-			analysis, err = provider.AnalyzePKGBUILD(ctx, *pkgInfo)
-		}
-
+		analysis, err = analyzeWith(ctx, provider, *pkgInfo, false)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -73,6 +73,7 @@ func init() {
 
 	// Add subcommands
 	rootCmd.AddCommand(newAnalyzeCmd())
+	rootCmd.AddCommand(newGradeCmd())
 	rootCmd.AddCommand(newCacheCmd())
 	rootCmd.AddCommand(newConfigCmd())
 	rootCmd.AddCommand(newProviderCmd())

--- a/internal/cmd/tree.go
+++ b/internal/cmd/tree.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aaronsb/yay-friend/internal/pkgbuild"
+	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/ui"
+)
+
+// resolvePKGBUILDPath accepts either a PKGBUILD file or the directory holding
+// one and returns the file.
+func resolvePKGBUILDPath(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return path, nil
+	}
+	pkgbuildPath := filepath.Join(path, "PKGBUILD")
+	if _, err := os.Stat(pkgbuildPath); err != nil {
+		return "", fmt.Errorf("no PKGBUILD in %s: %w", path, err)
+	}
+	return pkgbuildPath, nil
+}
+
+// collectPackageTree reads a PKGBUILD and every companion file it references —
+// the .install hook and any source= entry shipped beside it — so the analyzer
+// sees the code that actually runs, not just the recipe that fetches it.
+//
+// It returns the path of the install script it found, if any, because that is
+// the one companion worth naming to the user: it is the part that runs as root.
+func collectPackageTree(pkgbuildPath string) (types.PackageInfo, string, error) {
+	content, err := os.ReadFile(pkgbuildPath)
+	if err != nil {
+		return types.PackageInfo{}, "", fmt.Errorf("failed to read PKGBUILD: %w", err)
+	}
+
+	pkgInfo, vars := parseLocalPKGBUILD(string(content), pkgbuildPath)
+	dir := filepath.Dir(pkgbuildPath)
+	pkgInfo.AdditionalFiles = make(map[string]string)
+
+	// Companion files are only discoverable when the PKGBUILD parses; an
+	// unparseable one still gets analyzed on its own source above.
+	var installScriptPath string
+	if vars != nil {
+		installScriptPath = findInstallScript(vars, dir)
+		if installScriptPath != "" {
+			if content, err := os.ReadFile(installScriptPath); err == nil {
+				pkgInfo.InstallScript = string(content)
+				pkgInfo.AdditionalFiles[filepath.Base(installScriptPath)] = string(content)
+			}
+		}
+
+		for _, file := range findAdditionalFiles(vars, dir) {
+			if content, err := os.ReadFile(filepath.Join(dir, file)); err == nil {
+				pkgInfo.AdditionalFiles[file] = string(content)
+			}
+		}
+	}
+
+	return pkgInfo, installScriptPath, nil
+}
+
+// parseLocalPKGBUILD extracts basic package information from a PKGBUILD.
+// A PKGBUILD that will not parse still yields a usable PackageInfo: the raw
+// source is what the analyzer reads, and metadata is only there to orient the
+// user.
+// It returns the parsed variables alongside the info so companion-file discovery
+// does not have to parse the same source a second time; vars is nil when the
+// PKGBUILD could not be parsed.
+func parseLocalPKGBUILD(content string, path string) (types.PackageInfo, *pkgbuild.Vars) {
+	info := types.PackageInfo{
+		PKGBUILD:   content,
+		Maintainer: "Unknown",
+		// Defaults for local analysis
+		AURPageURL:     "Local PKGBUILD",
+		LastUpdated:    "Not available (local PKGBUILD)",
+		FirstSubmitted: "Not available (local PKGBUILD)",
+	}
+
+	vars, err := pkgbuild.Parse(content)
+	if err != nil {
+		ui.Warn("could not parse %s as shell (%v); analyzing raw source", path, err)
+		return info, nil
+	}
+
+	info.Name = vars.Name()
+	info.Version = vars.Str("pkgver")
+	info.Description = vars.Str("pkgdesc")
+	info.URL = vars.Str("url")
+	info.Maintainer = vars.Maintainer()
+	info.Dependencies = vars.Slice("depends")
+	info.MakeDepends = vars.Slice("makedepends")
+	info.OptDepends = vars.Slice("optdepends")
+
+	return info, vars
+}
+
+// findInstallScript returns the path to the .install script referenced by the
+// PKGBUILD, if that file exists alongside it.
+func findInstallScript(vars *pkgbuild.Vars, dir string) string {
+	name := vars.Install()
+	if name == "" {
+		return ""
+	}
+	path := filepath.Join(dir, name)
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+// findAdditionalFiles returns the source= entries that name a file present in
+// the PKGBUILD's directory, so their contents can be sent for analysis too.
+func findAdditionalFiles(vars *pkgbuild.Vars, dir string) []string {
+	var files []string
+	for _, name := range vars.LocalSources() {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			files = append(files, name)
+		}
+	}
+	return files
+}
+
+// treeVersion returns the full package version of a staged tree, in makepkg's
+// own spelling: [epoch:]pkgver[-pkgrel].
+//
+// .SRCINFO is preferred because it is already expanded — a PKGBUILD whose
+// pkgver() function computes the version from a git checkout has no usable
+// pkgver in its source. Best effort throughout: this only feeds an optional,
+// display-only field, and a tree without either is not a failure.
+func treeVersion(dir string) string {
+	if v := srcinfoVersion(filepath.Join(dir, ".SRCINFO")); v != "" {
+		return v
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "PKGBUILD"))
+	if err != nil {
+		return ""
+	}
+	vars, err := pkgbuild.Parse(string(content))
+	if err != nil {
+		return ""
+	}
+	return joinVersion(vars.Str("epoch"), vars.Str("pkgver"), vars.Str("pkgrel"))
+}
+
+// srcinfoVersion reads epoch/pkgver/pkgrel out of a .SRCINFO. The format is
+// "key = value" lines, indented under pkgbase; the first declaration of each
+// key is the package-wide one, and a later per-package override is not what a
+// grading is about.
+func srcinfoVersion(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	var epoch, pkgver, pkgrel string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		key, value, found := strings.Cut(scanner.Text(), "=")
+		if !found {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "epoch":
+			if epoch == "" {
+				epoch = value
+			}
+		case "pkgver":
+			if pkgver == "" {
+				pkgver = value
+			}
+		case "pkgrel":
+			if pkgrel == "" {
+				pkgrel = value
+			}
+		}
+	}
+
+	return joinVersion(epoch, pkgver, pkgrel)
+}
+
+func joinVersion(epoch, pkgver, pkgrel string) string {
+	if pkgver == "" {
+		return ""
+	}
+	var b strings.Builder
+	if epoch != "" {
+		b.WriteString(epoch)
+		b.WriteString(":")
+	}
+	b.WriteString(pkgver)
+	if pkgrel != "" {
+		b.WriteString("-")
+		b.WriteString(pkgrel)
+	}
+	return b.String()
+}

--- a/internal/cmd/tree.go
+++ b/internal/cmd/tree.go
@@ -29,6 +29,29 @@ func resolvePKGBUILDPath(path string) (string, error) {
 	return pkgbuildPath, nil
 }
 
+// readRegular reads a file after proving it is a regular file. The tree's
+// paths are chosen by whoever staged it, and os.ReadFile on a FIFO blocks in
+// open() forever — past SIGTERM, since main's signal context replaces
+// die-on-signal with a cancel no file read observes. Refusing anything
+// irregular keeps a hostile tree from hanging a grade that a caller then has
+// to SIGKILL.
+func readRegular(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	// A symlink is followed one hop and its target held to the same rule.
+	if info.Mode()&os.ModeSymlink != 0 {
+		if info, err = os.Stat(path); err != nil {
+			return nil, err
+		}
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return os.ReadFile(path)
+}
+
 // collectPackageTree reads a PKGBUILD and every companion file it references —
 // the .install hook and any source= entry shipped beside it — so the analyzer
 // sees the code that actually runs, not just the recipe that fetches it.
@@ -36,7 +59,7 @@ func resolvePKGBUILDPath(path string) (string, error) {
 // It returns the path of the install script it found, if any, because that is
 // the one companion worth naming to the user: it is the part that runs as root.
 func collectPackageTree(pkgbuildPath string) (types.PackageInfo, string, error) {
-	content, err := os.ReadFile(pkgbuildPath)
+	content, err := readRegular(pkgbuildPath)
 	if err != nil {
 		return types.PackageInfo{}, "", fmt.Errorf("failed to read PKGBUILD: %w", err)
 	}
@@ -51,14 +74,14 @@ func collectPackageTree(pkgbuildPath string) (types.PackageInfo, string, error) 
 	if vars != nil {
 		installScriptPath = findInstallScript(vars, dir)
 		if installScriptPath != "" {
-			if content, err := os.ReadFile(installScriptPath); err == nil {
+			if content, err := readRegular(installScriptPath); err == nil {
 				pkgInfo.InstallScript = string(content)
 				pkgInfo.AdditionalFiles[filepath.Base(installScriptPath)] = string(content)
 			}
 		}
 
 		for _, file := range findAdditionalFiles(vars, dir) {
-			if content, err := os.ReadFile(filepath.Join(dir, file)); err == nil {
+			if content, err := readRegular(filepath.Join(dir, file)); err == nil {
 				pkgInfo.AdditionalFiles[file] = string(content)
 			}
 		}
@@ -139,7 +162,7 @@ func treeVersion(dir string) string {
 	if v := srcinfoVersion(filepath.Join(dir, ".SRCINFO")); v != "" {
 		return v
 	}
-	content, err := os.ReadFile(filepath.Join(dir, "PKGBUILD"))
+	content, err := readRegular(filepath.Join(dir, "PKGBUILD"))
 	if err != nil {
 		return ""
 	}

--- a/internal/cmd/usage.go
+++ b/internal/cmd/usage.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// usageError marks a failure that is about how the command was called, rather
+// than about the world it was called in.
+//
+// The distinction earns its keep on the commands whose stdout is a machine's
+// input. Cobra prints usage for every RunE error by default, and prints it to
+// the command's own output writer — so an analysis that failed because the
+// model was unreachable would answer with a flag list, on the stream a caller
+// is parsing as JSON. Those commands silence that and route the one case where
+// usage genuinely helps back through here, onto stderr.
+type usageError struct{ error }
+
+// withUsage runs fn, printing usage on stderr if it fails for a usage reason.
+func withUsage(cmd *cobra.Command, fn func() error) error {
+	err := fn()
+	var usage usageError
+	if errors.As(err, &usage) {
+		fmt.Fprintln(cmd.ErrOrStderr(), cmd.UsageString())
+	}
+	return err
+}

--- a/internal/grade/report.go
+++ b/internal/grade/report.go
@@ -1,0 +1,227 @@
+// Package grade translates a yay-friend security analysis into a
+// pacrat-grade/v1 report.
+//
+// pacrat (https://github.com/aaronsb/pacrat) gates AUR package updates on a
+// grade produced by any program that speaks its contract. The contract is
+// deliberately narrow: a grader answers "how alarming is this tree, on a scale
+// it declares", and nothing else. PROCEED / WARN / BLOCK is pacrat's data,
+// derived from that number by the host's own thresholds — so nothing in this
+// package recommends, gates, or approves. yay-friend's own recommendation rides
+// along in meta, where it is advisory and cannot move a verdict.
+//
+// This package is yay-friend's side of that boundary, and the whole of it: the
+// contract is a JSON shape, so translating to it is a marshalling concern and
+// belongs nowhere near the analyzer. What was previously done outside this repo
+// by contrib/graders/yay-friend-grade — a jq program in pacrat's tree — now
+// happens here, and the numbers it produces are identical by construction (see
+// the mapping notes on FromAnalysis).
+package grade
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/version"
+)
+
+const (
+	// Contract is compared byte for byte by pacrat. A report written to a
+	// contract it does not know is not read at all.
+	Contract = "pacrat-grade/v1"
+
+	// Grader names the producer. Informational: pacrat files a grading under
+	// the name in its own config and only mentions this one if they differ.
+	Grader = "yay-friend"
+
+	// ScaleMin and ScaleMax are yay-friend's entropy scale, which happens to be
+	// pacrat's default. Declared explicitly all the same: it costs one line and
+	// it makes a later change to the output visible instead of silent.
+	ScaleMin = 0
+	ScaleMax = int(types.EntropyCritical)
+
+	// maxFindings bounds the advisory list. pacrat shows the five worst and
+	// counts the rest, so a hundred annotations buy nothing and a grading is
+	// supposed to be a few kilobytes of JSON.
+	maxFindings = 25
+
+	// maxTitle and maxNote bound two strings that pass through a file an
+	// attacker may have written. pacrat neuters control characters and flattens
+	// each string onto one line before display; a grader that leans on its
+	// reader to sanitize is a grader that breaks the next reader.
+	maxTitle = 240
+	maxNote  = 200
+)
+
+// Report is a pacrat-grade/v1 grading.
+type Report struct {
+	Contract string    `json:"contract"`
+	Grader   string    `json:"grader"`
+	Subject  Subject   `json:"subject"`
+	Grade    int       `json:"grade"`
+	Scale    Scale     `json:"scale"`
+	Findings []Finding `json:"findings"`
+	Meta     Meta      `json:"meta"`
+}
+
+// Subject is what was graded. package and commit are echoed back exactly as
+// pacrat spelled them: pacrat compares them against its own idea of the subject
+// and discards a grading of anything else.
+type Subject struct {
+	Package string `json:"package"`
+	Commit  string `json:"commit"`
+	Version string `json:"version,omitempty"`
+}
+
+// Scale is the range Grade lives on.
+type Scale struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+// Finding is one thing a human should look at. Advisory: findings never move
+// the grade, the grade moves the verdict.
+type Finding struct {
+	Level int    `json:"level"`
+	Title string `json:"title"`
+	Span  string `json:"span,omitempty"`
+}
+
+// Meta is opaque to pacrat and preserved verbatim, with one convention: Note is
+// printed under the result, so yay-friend's one-line summary goes there.
+type Meta struct {
+	Cached           bool   `json:"cached"`
+	Provider         string `json:"provider,omitempty"`
+	Note             string `json:"note,omitempty"`
+	Recommendation   string `json:"recommendation,omitempty"`
+	YayFriendVersion string `json:"yay_friend_version,omitempty"`
+}
+
+// FromAnalysis builds a grading of subj from a yay-friend analysis.
+//
+// The mapping is fixed by what the contrib adapter already did, so that a host
+// running the old shim and a host running this subcommand read the same numbers
+// off the same tree:
+//
+//   - grade is overall entropy as an integer, refused rather than squeezed into
+//     range. Clamping a negative to 0 would turn a broken analysis into a
+//     PROCEED, and clamping a 70 to 4 would invent a BLOCK nobody reported;
+//     both are the approximation the contract says to decline.
+//   - a finding's level is its entropy, clamped instead. Finding levels are
+//     advisory and do not move the grade, so a level outside 0-255 would be
+//     rejected by pacrat's parser and cost a whole grading over one annotation.
+//   - a finding's span is PKGBUILD:<line> when the analyzer reported a line, and
+//     absent otherwise. yay-friend does not record which file a finding came
+//     from, so the adapter's per-file span was already always the PKGBUILD.
+//
+// cached says whether the analysis was replayed from yay-friend's own cache
+// rather than produced by a model on this run.
+func FromAnalysis(subj Subject, a *types.SecurityAnalysis, cached bool) (*Report, error) {
+	if a == nil {
+		return nil, fmt.Errorf("no analysis to grade")
+	}
+	entropy := int(a.OverallEntropy)
+	if entropy < ScaleMin || entropy > ScaleMax {
+		return nil, fmt.Errorf("overall entropy is %d, which is not a %d-%d level",
+			entropy, ScaleMin, ScaleMax)
+	}
+
+	findings := a.Findings
+	if len(findings) > maxFindings {
+		findings = findings[:maxFindings]
+	}
+	// Non-nil so an analysis with nothing to report marshals as [] rather than
+	// null. Both parse, but the contract's default is an empty list and a reader
+	// looking at the JSON should see one.
+	out := make([]Finding, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, Finding{
+			Level: clamp(int(f.Entropy)),
+			Title: title(f),
+			Span:  span(f),
+		})
+	}
+
+	return &Report{
+		Contract: Contract,
+		Grader:   Grader,
+		Subject:  subj,
+		Grade:    entropy,
+		Scale:    Scale{Min: ScaleMin, Max: ScaleMax},
+		Findings: out,
+		Meta: Meta{
+			Cached:           cached,
+			Provider:         oneline(a.Provider),
+			Note:             truncate(oneline(a.Summary), maxNote),
+			Recommendation:   oneline(a.Recommendation),
+			YayFriendVersion: oneline(version.Version),
+		},
+	}, nil
+}
+
+func title(f types.SecurityFinding) string {
+	parts := make([]string, 0, 2)
+	for _, s := range []string{oneline(f.Type), oneline(f.Description)} {
+		if s != "" {
+			parts = append(parts, s)
+		}
+	}
+	t := truncate(strings.Join(parts, ": "), maxTitle)
+	if t == "" {
+		return "(no description)"
+	}
+	return t
+}
+
+func span(f types.SecurityFinding) string {
+	if f.LineNumber <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("PKGBUILD:%d", f.LineNumber)
+}
+
+func clamp(level int) int {
+	if level < ScaleMin {
+		return ScaleMin
+	}
+	if level > ScaleMax {
+		return ScaleMax
+	}
+	return level
+}
+
+// oneline flattens s onto a single line and strips the control characters that
+// would let a hostile PKGBUILD forge a line of pacrat's own report. Whitespace
+// collapses first, so a newline becomes a space rather than welding two words
+// together when the remaining controls are removed.
+func oneline(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	space := false
+	for _, r := range s {
+		switch {
+		case unicode.IsSpace(r):
+			space = true
+		case r < 0x20 || r == 0x7f:
+			// Dropped outright: these are the forging characters, and they
+			// separate nothing.
+		default:
+			if space && b.Len() > 0 {
+				b.WriteRune(' ')
+			}
+			space = false
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// truncate cuts s to at most n runes, marking the cut with an ellipsis.
+func truncate(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n-1]) + "…"
+}

--- a/internal/grade/report.go
+++ b/internal/grade/report.go
@@ -116,8 +116,12 @@ type Meta struct {
 //     from, so the adapter's per-file span was already always the PKGBUILD.
 //
 // cached says whether the analysis was replayed from yay-friend's own cache
-// rather than produced by a model on this run.
-func FromAnalysis(subj Subject, a *types.SecurityAnalysis, cached bool) (*Report, error) {
+// rather than produced by a model on this run. producedBy names the
+// yay-friend version that produced the analysis — the cache entry's on a
+// replay, empty for "this build" — because that is what the adapter reported
+// under the same key, and a version that silently changed referent would
+// disagree with it on every replayed hit.
+func FromAnalysis(subj Subject, a *types.SecurityAnalysis, cached bool, producedBy string) (*Report, error) {
 	if a == nil {
 		return nil, fmt.Errorf("no analysis to grade")
 	}
@@ -151,11 +155,16 @@ func FromAnalysis(subj Subject, a *types.SecurityAnalysis, cached bool) (*Report
 		Scale:    Scale{Min: ScaleMin, Max: ScaleMax},
 		Findings: out,
 		Meta: Meta{
-			Cached:           cached,
-			Provider:         oneline(a.Provider),
-			Note:             truncate(oneline(a.Summary), maxNote),
-			Recommendation:   oneline(a.Recommendation),
-			YayFriendVersion: oneline(version.Version),
+			Cached:         cached,
+			Provider:       oneline(a.Provider),
+			Note:           truncate(oneline(a.Summary), maxNote),
+			Recommendation: oneline(a.Recommendation),
+			YayFriendVersion: oneline(func() string {
+				if producedBy != "" {
+					return producedBy
+				}
+				return version.Version
+			}()),
 		},
 	}, nil
 }

--- a/internal/grade/report_test.go
+++ b/internal/grade/report_test.go
@@ -52,7 +52,7 @@ func helloSubject() Subject {
 }
 
 func TestFromAnalysisMatchesTheAdapterMapping(t *testing.T) {
-	report, err := FromAnalysis(helloSubject(), helloAnalysis(), true)
+	report, err := FromAnalysis(helloSubject(), helloAnalysis(), true, "")
 	if err != nil {
 		t.Fatalf("FromAnalysis: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestFromAnalysisRefusesEntropyOutsideTheScale(t *testing.T) {
 		analysis := helloAnalysis()
 		analysis.OverallEntropy = entropy
 
-		report, err := FromAnalysis(helloSubject(), analysis, false)
+		report, err := FromAnalysis(helloSubject(), analysis, false, "")
 		if err == nil {
 			t.Errorf("entropy %d: expected a refusal, got grade %d", entropy, report.Grade)
 		}
@@ -124,7 +124,7 @@ func TestFromAnalysisRefusesEntropyOutsideTheScale(t *testing.T) {
 }
 
 func TestFromAnalysisRefusesANilAnalysis(t *testing.T) {
-	if _, err := FromAnalysis(helloSubject(), nil, false); err == nil {
+	if _, err := FromAnalysis(helloSubject(), nil, false, ""); err == nil {
 		t.Error("expected a refusal for a nil analysis")
 	}
 }
@@ -137,7 +137,7 @@ func TestFromAnalysisClampsFindingLevels(t *testing.T) {
 	analysis.Findings[0].Entropy = 4000
 	analysis.Findings[1].Entropy = -7
 
-	report, err := FromAnalysis(helloSubject(), analysis, false)
+	report, err := FromAnalysis(helloSubject(), analysis, false, "")
 	if err != nil {
 		t.Fatalf("a wild finding level must not cost the grading: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestFromAnalysisFlattensAndStripsTitles(t *testing.T) {
 	analysis := helloAnalysis()
 	analysis.Findings[0].Description = "before\x1b[31m\x07mid\x7fafter"
 
-	report, err := FromAnalysis(helloSubject(), analysis, false)
+	report, err := FromAnalysis(helloSubject(), analysis, false, "")
 	if err != nil {
 		t.Fatalf("control characters should not fail the grading: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestFromAnalysisDescribesAFindingWithNoText(t *testing.T) {
 	analysis := helloAnalysis()
 	analysis.Findings = []types.SecurityFinding{{Entropy: types.EntropyHigh}}
 
-	report, err := FromAnalysis(helloSubject(), analysis, false)
+	report, err := FromAnalysis(helloSubject(), analysis, false, "")
 	if err != nil {
 		t.Fatalf("FromAnalysis: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestFromAnalysisCapsFindings(t *testing.T) {
 		})
 	}
 
-	report, err := FromAnalysis(helloSubject(), analysis, false)
+	report, err := FromAnalysis(helloSubject(), analysis, false, "")
 	if err != nil {
 		t.Fatalf("a long findings list should still grade: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestFromAnalysisTruncatesLongText(t *testing.T) {
 	analysis.Findings[0].Description = strings.Repeat("x", 500)
 	analysis.Summary = strings.Repeat("y", 500)
 
-	report, err := FromAnalysis(helloSubject(), analysis, false)
+	report, err := FromAnalysis(helloSubject(), analysis, false, "")
 	if err != nil {
 		t.Fatalf("FromAnalysis: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestReportWithNoFindingsMarshalsAnEmptyList(t *testing.T) {
 	analysis := helloAnalysis()
 	analysis.Findings = nil
 
-	report, err := FromAnalysis(helloSubject(), analysis, false)
+	report, err := FromAnalysis(helloSubject(), analysis, false, "")
 	if err != nil {
 		t.Fatalf("FromAnalysis: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestReportConformsToTheContract(t *testing.T) {
 	analysis := helloAnalysis()
 	analysis.OverallEntropy = types.EntropyCritical
 
-	report, err := FromAnalysis(helloSubject(), analysis, true)
+	report, err := FromAnalysis(helloSubject(), analysis, true, "")
 	if err != nil {
 		t.Fatalf("FromAnalysis: %v", err)
 	}

--- a/internal/grade/report_test.go
+++ b/internal/grade/report_test.go
@@ -1,0 +1,358 @@
+package grade
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/version"
+)
+
+// helloAnalysis is the analysis behind the cache entry the contrib adapter's
+// test suite grades (pacrat's contrib/graders/test-yay-friend-grade.sh). The
+// expectations below are that suite's expectations: a host running the shim and
+// a host running `yay-friend grade` must read the same numbers off the same
+// tree, and this is where the two mappings are held together.
+func helloAnalysis() *types.SecurityAnalysis {
+	return &types.SecurityAnalysis{
+		PackageName:    "hello",
+		OverallEntropy: types.EntropyLow,
+		OverallLevel:   types.EntropyLow,
+		Findings: []types.SecurityFinding{
+			{
+				Type:        "source_analysis",
+				Entropy:     types.EntropyModerate,
+				Severity:    types.EntropyModerate,
+				Description: "Source downloaded from official GNU FTP\n  server",
+				LineNumber:  12,
+				Context:     "source=(https://ftp.gnu.org/gnu/hello/$pkgname-$pkgver.tar.gz)",
+				Suggestion:  "Legitimate source location",
+			},
+			{
+				Type:        "maintainer_trust",
+				Entropy:     types.EntropyLow,
+				Severity:    types.EntropyLow,
+				Description: "Package has low popularity but is actively maintained",
+			},
+		},
+		Summary:        "Clean package.",
+		Recommendation: "PROCEED",
+		Provider:       "claude",
+	}
+}
+
+func helloSubject() Subject {
+	return Subject{
+		Package: "hello",
+		Commit:  "51cec6333515471681ec8aa00943145d420311fa",
+		Version: "2.12.1-1",
+	}
+}
+
+func TestFromAnalysisMatchesTheAdapterMapping(t *testing.T) {
+	report, err := FromAnalysis(helloSubject(), helloAnalysis(), true)
+	if err != nil {
+		t.Fatalf("FromAnalysis: %v", err)
+	}
+
+	if report.Contract != "pacrat-grade/v1" {
+		t.Errorf("contract = %q, want pacrat-grade/v1", report.Contract)
+	}
+	if report.Grader != "yay-friend" {
+		t.Errorf("grader = %q, want yay-friend", report.Grader)
+	}
+	if report.Grade != 1 {
+		t.Errorf("grade = %d, want 1", report.Grade)
+	}
+	if report.Scale != (Scale{Min: 0, Max: 4}) {
+		t.Errorf("scale = %+v, want {0 4}", report.Scale)
+	}
+	if report.Subject != helloSubject() {
+		t.Errorf("subject = %+v, want %+v", report.Subject, helloSubject())
+	}
+
+	want := []Finding{
+		{
+			Level: 2,
+			Title: "source_analysis: Source downloaded from official GNU FTP server",
+			Span:  "PKGBUILD:12",
+		},
+		{
+			Level: 1,
+			Title: "maintainer_trust: Package has low popularity but is actively maintained",
+		},
+	}
+	if len(report.Findings) != len(want) {
+		t.Fatalf("got %d findings, want %d", len(report.Findings), len(want))
+	}
+	for i := range want {
+		if report.Findings[i] != want[i] {
+			t.Errorf("finding %d = %+v, want %+v", i, report.Findings[i], want[i])
+		}
+	}
+
+	wantMeta := Meta{
+		Cached:           true,
+		Provider:         "claude",
+		Note:             "Clean package.",
+		Recommendation:   "PROCEED",
+		YayFriendVersion: version.Version,
+	}
+	if report.Meta != wantMeta {
+		t.Errorf("meta = %+v, want %+v", report.Meta, wantMeta)
+	}
+}
+
+// An overall entropy the report cannot place on 0-4 is refused, never squeezed
+// into range: clamping a negative to 0 would turn a broken analysis into a
+// PROCEED, and clamping a 70 to 4 would invent a BLOCK nobody reported.
+func TestFromAnalysisRefusesEntropyOutsideTheScale(t *testing.T) {
+	for _, entropy := range []types.SecurityEntropy{-1, 5, 70, 256} {
+		analysis := helloAnalysis()
+		analysis.OverallEntropy = entropy
+
+		report, err := FromAnalysis(helloSubject(), analysis, false)
+		if err == nil {
+			t.Errorf("entropy %d: expected a refusal, got grade %d", entropy, report.Grade)
+		}
+		if report != nil {
+			t.Errorf("entropy %d: a refusal must not produce a partial grading", entropy)
+		}
+	}
+}
+
+func TestFromAnalysisRefusesANilAnalysis(t *testing.T) {
+	if _, err := FromAnalysis(helloSubject(), nil, false); err == nil {
+		t.Error("expected a refusal for a nil analysis")
+	}
+}
+
+// A finding level, by contrast, is advisory and is clamped: pacrat's parser
+// takes 0-255 and rejects the whole grading outside it, so a broken annotation
+// must not be allowed to cost the grade.
+func TestFromAnalysisClampsFindingLevels(t *testing.T) {
+	analysis := helloAnalysis()
+	analysis.Findings[0].Entropy = 4000
+	analysis.Findings[1].Entropy = -7
+
+	report, err := FromAnalysis(helloSubject(), analysis, false)
+	if err != nil {
+		t.Fatalf("a wild finding level must not cost the grading: %v", err)
+	}
+	if report.Grade != 1 {
+		t.Errorf("grade = %d, want 1 (findings do not move the grade)", report.Grade)
+	}
+	if got := []int{report.Findings[0].Level, report.Findings[1].Level}; got[0] != 4 || got[1] != 0 {
+		t.Errorf("levels = %v, want [4 0]", got)
+	}
+}
+
+// Every string here is printed on pacrat's own report, having just passed
+// through a file an attacker may have written. A newline in a title would let a
+// grader forge a line of that report.
+func TestFromAnalysisFlattensAndStripsTitles(t *testing.T) {
+	analysis := helloAnalysis()
+	analysis.Findings[0].Description = "before\x1b[31m\x07mid\x7fafter"
+
+	report, err := FromAnalysis(helloSubject(), analysis, false)
+	if err != nil {
+		t.Fatalf("control characters should not fail the grading: %v", err)
+	}
+
+	got := report.Findings[0].Title
+	if want := "source_analysis: before[31mmidafter"; got != want {
+		t.Errorf("title = %q, want %q", got, want)
+	}
+	for _, r := range got {
+		if r < 0x20 || r == 0x7f {
+			t.Errorf("title %q still carries control character %q", got, r)
+		}
+	}
+}
+
+func TestFromAnalysisDescribesAFindingWithNoText(t *testing.T) {
+	analysis := helloAnalysis()
+	analysis.Findings = []types.SecurityFinding{{Entropy: types.EntropyHigh}}
+
+	report, err := FromAnalysis(helloSubject(), analysis, false)
+	if err != nil {
+		t.Fatalf("FromAnalysis: %v", err)
+	}
+	if report.Findings[0].Title != "(no description)" {
+		t.Errorf("title = %q, want (no description)", report.Findings[0].Title)
+	}
+	if report.Findings[0].Span != "" {
+		t.Errorf("span = %q, want none for a finding with no line", report.Findings[0].Span)
+	}
+}
+
+func TestFromAnalysisCapsFindings(t *testing.T) {
+	analysis := helloAnalysis()
+	analysis.Findings = nil
+	for i := 0; i < 60; i++ {
+		analysis.Findings = append(analysis.Findings, types.SecurityFinding{
+			Type:        "source_analysis",
+			Entropy:     types.EntropyModerate,
+			Description: fmt.Sprintf("finding %d", i),
+		})
+	}
+
+	report, err := FromAnalysis(helloSubject(), analysis, false)
+	if err != nil {
+		t.Fatalf("a long findings list should still grade: %v", err)
+	}
+	if len(report.Findings) != maxFindings {
+		t.Errorf("got %d findings, want %d", len(report.Findings), maxFindings)
+	}
+}
+
+func TestFromAnalysisTruncatesLongText(t *testing.T) {
+	analysis := helloAnalysis()
+	analysis.Findings[0].Type = ""
+	analysis.Findings[0].Description = strings.Repeat("x", 500)
+	analysis.Summary = strings.Repeat("y", 500)
+
+	report, err := FromAnalysis(helloSubject(), analysis, false)
+	if err != nil {
+		t.Fatalf("FromAnalysis: %v", err)
+	}
+	if n := len([]rune(report.Findings[0].Title)); n != maxTitle {
+		t.Errorf("title is %d runes, want %d", n, maxTitle)
+	}
+	if !strings.HasSuffix(report.Findings[0].Title, "…") {
+		t.Error("a truncated title should say so")
+	}
+	if n := len([]rune(report.Meta.Note)); n != maxNote {
+		t.Errorf("note is %d runes, want %d", n, maxNote)
+	}
+}
+
+// An analysis with nothing to report marshals its findings as [] rather than
+// null. Both parse, but the contract's default is an empty list.
+func TestReportWithNoFindingsMarshalsAnEmptyList(t *testing.T) {
+	analysis := helloAnalysis()
+	analysis.Findings = nil
+
+	report, err := FromAnalysis(helloSubject(), analysis, false)
+	if err != nil {
+		t.Fatalf("FromAnalysis: %v", err)
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"findings":[]`) {
+		t.Errorf("findings should marshal as []: %s", data)
+	}
+}
+
+// contractReport mirrors pacrat-grade/v1 as pacrat reads it, with every field a
+// pointer or an interface so "absent" and "present but wrong type" are
+// distinguishable. Decoding through it is the check that what we emit is what
+// the contract describes, rather than what our own structs happen to say.
+type contractReport struct {
+	Contract *string `json:"contract"`
+	Grader   *string `json:"grader"`
+	Subject  *struct {
+		Package *string `json:"package"`
+		Commit  *string `json:"commit"`
+		Version *string `json:"version"`
+	} `json:"subject"`
+	Grade *json.Number `json:"grade"`
+	Scale *struct {
+		Min *json.Number `json:"min"`
+		Max *json.Number `json:"max"`
+	} `json:"scale"`
+	Findings []struct {
+		Level *json.Number `json:"level"`
+		Title *string      `json:"title"`
+		Span  *string      `json:"span"`
+	} `json:"findings"`
+	Meta map[string]any `json:"meta"`
+}
+
+func TestReportConformsToTheContract(t *testing.T) {
+	analysis := helloAnalysis()
+	analysis.OverallEntropy = types.EntropyCritical
+
+	report, err := FromAnalysis(helloSubject(), analysis, true)
+	if err != nil {
+		t.Fatalf("FromAnalysis: %v", err)
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got contractReport
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("the grading does not decode as pacrat-grade/v1: %v", err)
+	}
+
+	if got.Contract == nil || *got.Contract != "pacrat-grade/v1" {
+		t.Fatalf("contract = %v, want pacrat-grade/v1", got.Contract)
+	}
+	if got.Grader == nil || *got.Grader == "" {
+		t.Error("grader is required and must be non-empty")
+	}
+	if got.Subject == nil {
+		t.Fatal("subject is required")
+	}
+	if got.Subject.Package == nil || *got.Subject.Package == "" {
+		t.Error("subject.package is required and must be non-empty")
+	}
+	if got.Subject.Commit == nil || *got.Subject.Commit == "" {
+		t.Error("subject.commit is required and must be non-empty")
+	}
+	if got.Grade == nil {
+		t.Fatal("grade is required")
+	}
+	if got.Scale == nil || got.Scale.Min == nil || got.Scale.Max == nil {
+		t.Fatal("scale was declared, so both bounds must be present")
+	}
+
+	min := mustU8(t, "scale.min", *got.Scale.Min)
+	max := mustU8(t, "scale.max", *got.Scale.Max)
+	if min >= max {
+		t.Errorf("scale %d-%d is degenerate", min, max)
+	}
+	grade := mustU8(t, "grade", *got.Grade)
+	if grade < min || grade > max {
+		t.Errorf("grade %d is outside the declared scale %d-%d", grade, min, max)
+	}
+
+	for i, f := range got.Findings {
+		if f.Level != nil {
+			mustU8(t, fmt.Sprintf("findings[%d].level", i), *f.Level)
+		}
+		if f.Title != nil && strings.ContainsAny(*f.Title, "\r\n") {
+			t.Errorf("findings[%d].title spans more than one line", i)
+		}
+	}
+
+	// meta is opaque to pacrat, with one convention: meta.note is printed under
+	// the result.
+	if note, ok := got.Meta["note"].(string); !ok || note == "" {
+		t.Errorf("meta.note = %v, want the analyzer's one-line summary", got.Meta["note"])
+	}
+	if cached, ok := got.Meta["cached"].(bool); !ok || !cached {
+		t.Errorf("meta.cached = %v, want true", got.Meta["cached"])
+	}
+}
+
+// mustU8 enforces the contract's one arithmetic rule: every number in a grading
+// is an integer in 0-255, and a fractional or out-of-range one fails to parse
+// rather than being clamped.
+func mustU8(t *testing.T, field string, n json.Number) int {
+	t.Helper()
+	i, err := n.Int64()
+	if err != nil {
+		t.Fatalf("%s = %s, which is not an integer", field, n)
+	}
+	if i < 0 || i > 255 {
+		t.Fatalf("%s = %d, which is not a u8", field, i)
+	}
+	return int(i)
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -107,6 +107,7 @@ type PackageInfo struct {
 	// Additional files for analysis
 	InstallScript   string            `json:"install_script,omitempty"`
 	AdditionalFiles map[string]string `json:"additional_files,omitempty"` // filename -> content
+	PKGBUILDPath    string            `json:"pkgbuild_path,omitempty"`    // where the PKGBUILD was read from, when local
 }
 
 // AIProvider interface for different AI backends


### PR DESCRIPTION
yay-friend becomes a first-class pacrat grader, and the teaching contrast the design wanted: a tool built for the contract is one string (`cmd = "yay-friend grade"`), a tool that never heard of it is one jq filter (now written out, runnable, in the README).

- **`yay-friend grade`** — emits pacrat-grade/v1 exactly: reads the `PACRAT_*` subject (flags override), grades the tree it was handed, files under the requested commit, replays cache hits without a model call. Byte-identical to the contrib adapter on the adapter's own fixture, outside documented `meta` differences. Failures are nonzero with zero bytes on stdout — pacrat reads a failed grader as UNGRADED-which-holds.
- **`analyze --json`** — the full analysis in yay-friend's own richer shape, machine-clean stdout.
- Drive-by fixes: short-commit `[:8]` panic; cobra usage printed onto the JSON stream.
- From the adversarial review: cache entries declaring another package are refused (the filename no longer decides identity), irregular files (FIFOs) in a tree are refused instead of hanging past SIGTERM, and `meta.yay_friend_version` keeps the adapter's meaning (the version that produced the analysis).

Reviewed adversarially: 27/27 stdout-purity attacks, cache-key injection canaries clean, hostile PKGBUILD content capped and stripped, end-to-end through pacrat's real binary (a hostile grading rendered safely and drove a BLOCK), per-commit green.

Verified: `go build ./...` · `go vet ./...` · `go test -count=1 ./...` all green.