### PR TITLE
fix: stop analyzing GitLab sign-in pages as PKGBUILDs

### DIFF
--- a/internal/aur/fetcher.go
+++ b/internal/aur/fetcher.go
@@ -128,6 +128,32 @@ func (f *AURFetcher) enrichFromAURData(aurData *AURPackageInfo, pkgInfo *types.P
 	// Set metadata
 	pkgInfo.Votes = aurData.NumVotes
 	pkgInfo.Popularity = aurData.Popularity
+
+	// The RPC response knows things the PKGBUILD cannot say, and the analyzer
+	// weighs all of it as a trust signal -- so anything left blank here is not a
+	// gap, it is a fabricated one. A package with a maintainer and a published
+	// version reaching the provider as "Maintainer: Unknown, Version: (empty)"
+	// gets marked down for exactly the risk the response in hand disproves.
+	switch {
+	case aurData.Maintainer == "":
+		// An orphaned package keeps whatever `# Maintainer:` comment its last
+		// maintainer left behind, so that comment cannot answer who is
+		// accountable for it now. Nobody is, and that is the signal.
+		pkgInfo.Maintainer = "Orphaned (no AUR maintainer)"
+	case pkgInfo.Maintainer == "" || pkgInfo.Maintainer == "Unknown":
+		pkgInfo.Maintainer = aurData.Maintainer
+	}
+	// The PKGBUILD is preferred where it spoke: its pkgver is the version being
+	// built, while the RPC carries the pkgrel-qualified version last published.
+	if pkgInfo.Version == "" {
+		pkgInfo.Version = aurData.Version
+	}
+	if pkgInfo.Description == "" {
+		pkgInfo.Description = aurData.Description
+	}
+	if pkgInfo.URL == "" {
+		pkgInfo.URL = aurData.URL
+	}
 	
 	// Set dependencies for analysis
 	pkgInfo.Dependencies = aurData.Depends

--- a/internal/aur/fetcher_test.go
+++ b/internal/aur/fetcher_test.go
@@ -1,0 +1,84 @@
+package aur
+
+import (
+	"testing"
+
+	"github.com/aaronsb/yay-friend/internal/types"
+)
+
+// TestEnrichBackfillsMetadata guards the defect where the RPC response was
+// fetched, read for votes and dates, and then dropped on the floor for
+// everything else. ya-claude-code reached the analyzer as "Maintainer: Unknown,
+// Version: (empty)" while the response in hand said aaronsb / 2.1.233-1 -- and
+// the analyzer marked the package down for the unknown maintainer it had just
+// been told about.
+func TestEnrichBackfillsMetadata(t *testing.T) {
+	aurData := &AURPackageInfo{
+		Name:        "ya-claude-code",
+		Version:     "2.1.233-1",
+		Description: "Claude Code CLI",
+		URL:         "https://github.com/anthropics/claude-code",
+		Maintainer:  "aaronsb",
+		NumVotes:    0,
+	}
+	// What a PKGBUILD that failed to parse leaves behind.
+	pkgInfo := &types.PackageInfo{Name: "ya-claude-code", Maintainer: "Unknown"}
+
+	(&AURFetcher{}).enrichFromAURData(aurData, pkgInfo)
+
+	if got, want := pkgInfo.Maintainer, "aaronsb"; got != want {
+		t.Errorf("Maintainer = %q, want %q", got, want)
+	}
+	if got, want := pkgInfo.Version, "2.1.233-1"; got != want {
+		t.Errorf("Version = %q, want %q", got, want)
+	}
+	if got, want := pkgInfo.Description, "Claude Code CLI"; got != want {
+		t.Errorf("Description = %q, want %q", got, want)
+	}
+	if got, want := pkgInfo.URL, "https://github.com/anthropics/claude-code"; got != want {
+		t.Errorf("URL = %q, want %q", got, want)
+	}
+}
+
+// TestEnrichPrefersPKGBUILDValues keeps the backfill from overwriting what the
+// PKGBUILD actually declares. Its pkgver is the version about to be built; the
+// RPC carries the pkgrel-qualified version last published, which is a different
+// fact.
+func TestEnrichPrefersPKGBUILDValues(t *testing.T) {
+	aurData := &AURPackageInfo{
+		Version:     "2.1.233-1",
+		Description: "stale AUR description",
+		Maintainer:  "aaronsb",
+	}
+	pkgInfo := &types.PackageInfo{
+		Version:     "2.1.240",
+		Description: "from the PKGBUILD",
+		Maintainer:  "Aaron Bockelie <aaronsb@gmail.com>",
+	}
+
+	(&AURFetcher{}).enrichFromAURData(aurData, pkgInfo)
+
+	if got, want := pkgInfo.Version, "2.1.240"; got != want {
+		t.Errorf("Version = %q, want %q", got, want)
+	}
+	if got, want := pkgInfo.Description, "from the PKGBUILD"; got != want {
+		t.Errorf("Description = %q, want %q", got, want)
+	}
+	if got, want := pkgInfo.Maintainer, "Aaron Bockelie <aaronsb@gmail.com>"; got != want {
+		t.Errorf("Maintainer = %q, want %q", got, want)
+	}
+}
+
+// TestEnrichFlagsOrphaned covers the case the `# Maintainer:` comment cannot
+// report: an orphaned package keeps the comment its last maintainer left, so a
+// package nobody is answerable for still names someone.
+func TestEnrichFlagsOrphaned(t *testing.T) {
+	aurData := &AURPackageInfo{Maintainer: ""}
+	pkgInfo := &types.PackageInfo{Maintainer: "Someone Who Left <x@y.z>"}
+
+	(&AURFetcher{}).enrichFromAURData(aurData, pkgInfo)
+
+	if got, want := pkgInfo.Maintainer, "Orphaned (no AUR maintainer)"; got != want {
+		t.Errorf("Maintainer = %q, want %q", got, want)
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -11,7 +11,19 @@ import (
 	"time"
 
 	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/version"
 )
+
+// CurrentCacheVersion is the schema of entries this build writes and the only
+// one it will read back.
+//
+// Bump it whenever a change alters what gets analyzed, not merely how a result
+// is stored. Entries are keyed by AUR commit hash, so a package whose PKGBUILD
+// has not moved is never re-analyzed on its own -- which means a verdict reached
+// over the wrong input stays authoritative forever unless something retires it.
+// 2.0 retires everything written before the fetch fix, when a package shadowed
+// by a binary repository was graded against Arch GitLab's sign-in page.
+const CurrentCacheVersion = "2.0"
 
 // CacheManager handles analysis result caching
 type CacheManager struct {
@@ -112,6 +124,13 @@ func (c *CacheManager) GetCachedEntry(packageName, commitHash string) (*CachedAn
 		return nil, fmt.Errorf("cache corruption: entry declares package %q, not %q",
 			cached.CacheMetadata.PackageName, packageName)
 	}
+	// An entry from an older schema is a miss, not an error: the caller's
+	// response to a miss is to analyze the package again, which is exactly what
+	// a retired entry needs.
+	if cached.CacheMetadata.CacheVersion != CurrentCacheVersion {
+		return nil, fmt.Errorf("cache miss: entry for %s@%s was written by cache version %q, want %q",
+			packageName, ShortHash(commitHash), cached.CacheMetadata.CacheVersion, CurrentCacheVersion)
+	}
 
 	return &cached, nil
 }
@@ -130,8 +149,8 @@ func (c *CacheManager) SaveAnalysis(packageName, commitHash string, analysis *ty
 			CommitHash:       commitHash,
 			PackageName:      packageName,
 			CachedAt:         time.Now(),
-			CacheVersion:     "1.0",
-			YayFriendVersion: "1.0.0", // TODO: Get this from build info
+			CacheVersion:     CurrentCacheVersion,
+			YayFriendVersion: version.Version,
 		},
 		Analysis: analysis,
 	}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -343,5 +344,52 @@ func TestACachedEntryDeclaringAnotherPackageIsRefused(t *testing.T) {
 	// The un-tampered entry still replays under its own name.
 	if _, err := cacheManager.GetCachedEntry("evil-other", commitHash); err != nil {
 		t.Errorf("the honest entry stopped replaying: %v", err)
+	}
+}
+
+// TestAnEntryFromAnOlderCacheVersionIsRetired covers the upgrade path for the
+// fetch fix. Entries are keyed by AUR commit hash, so a package whose PKGBUILD
+// has not moved is never re-analyzed on its own -- a verdict reached over Arch
+// GitLab's sign-in page would otherwise outlive the bug that produced it.
+func TestAnEntryFromAnOlderCacheVersionIsRetired(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "yay-friend-cache-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	cacheManager := &CacheManager{cacheDir: tmpDir}
+
+	commitHash := "1234567890abcdef1234567890abcdef12345678"
+	analysis := &types.SecurityAnalysis{
+		PackageName: "ya-claude-code",
+		Summary:     "No PKGBUILD was actually analyzed.",
+		AnalyzedAt:  time.Now(),
+	}
+	if err := cacheManager.SaveAnalysis("ya-claude-code", commitHash, analysis); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite the entry as a pre-fix one, through the real writer.
+	path := cacheManager.getCacheFilePath("ya-claude-code", commitHash)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cached CachedAnalysis
+	if err := json.Unmarshal(data, &cached); err != nil {
+		t.Fatal(err)
+	}
+	cached.CacheMetadata.CacheVersion = "1.0"
+	if data, err = json.Marshal(cached); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cacheManager.GetCachedEntry("ya-claude-code", commitHash); err == nil {
+		t.Fatal("an entry written before the fetch fix was replayed")
+	} else if !strings.Contains(err.Error(), "cache miss") {
+		t.Errorf("a retired entry should read as a miss so the caller re-analyzes: %v", err)
 	}
 }

--- a/internal/pkgbuild/pkgbuild.go
+++ b/internal/pkgbuild/pkgbuild.go
@@ -17,6 +17,7 @@ package pkgbuild
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -115,6 +116,24 @@ func Parse(src string) (*Vars, error) {
 
 	v.maintainer = findMaintainer(src)
 	return v, nil
+}
+
+// nameDecl matches a pkgname= or pkgbase= assignment at the start of a line.
+// The leading boundary is what keeps `_pkgname=` -- present in most PKGBUILDs
+// that use the -bin/-git idiom -- from answering for the real declaration.
+var nameDecl = regexp.MustCompile(`(?m)^[ \t]*(pkgname|pkgbase)=`)
+
+// LooksLike reports whether src is plausibly a PKGBUILD at all.
+//
+// This answers "did we fetch the right thing", not "is this safe", and the two
+// want opposite thresholds. It is deliberately loose and deliberately not Parse:
+// every PKGBUILD declares pkgname or pkgbase, so source that declares neither is
+// something other than a PKGBUILD -- an HTML error page, a "package not found"
+// line, an empty response -- while source that does declare one belongs in front
+// of the analyzer even when Parse rejects it, because bash that will not parse is
+// itself a reason to look closer.
+func LooksLike(src string) bool {
+	return nameDecl.MatchString(src)
 }
 
 // Str returns a scalar declaration, or "" if absent.

--- a/internal/pkgbuild/pkgbuild_test.go
+++ b/internal/pkgbuild/pkgbuild_test.go
@@ -427,3 +427,34 @@ func TestParseErrorIsReported(t *testing.T) {
 		t.Fatal("Parse succeeded on malformed input, want error")
 	}
 }
+
+// TestLooksLike covers the fetch check. The HTML case is the one that motivated
+// it: `yay -G --print` on a package that a binary repository shadows prints
+// Arch's GitLab sign-in page and exits 0, and that page went to the analyzer as
+// the PKGBUILD.
+func TestLooksLike(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"plain pkgbuild", "# Maintainer: A <a@b.c>\npkgname=foo\npkgver=1.0\n", true},
+		{"yay header prefix", "# foo\n\npkgname=foo\n", true},
+		{"pkgbase only", "pkgbase=foo\npkgname=('foo' 'foo-docs')\n", true},
+		{"indented", "\tpkgname=foo\n", true},
+		{"unparseable but real", "pkgname=foo\ndepends=(unclosed\n", true},
+
+		{"gitlab sign-in page", "# foo\n\n<!DOCTYPE html>\n<html>\n<title>Sign in · GitLab</title>\n", false},
+		{"yay not-found line", " -> Unable to find the following packages: foo\n", false},
+		{"empty", "", false},
+		{"header only", "# foo\n\n", false},
+		{"underscore prefix alone", "_pkgname=foo\n_pkgbase=foo\n", false},
+		{"mentioned in prose", "# this file sets pkgname= later\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LooksLike(tc.src); got != tc.want {
+				t.Errorf("LooksLike() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/yay/yay.go
+++ b/internal/yay/yay.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aaronsb/yay-friend/internal/pkgbuild"
 	"github.com/aaronsb/yay-friend/internal/types"
+	"github.com/aaronsb/yay-friend/internal/ui"
 )
 
 // PackageSearchResult represents a search result from yay
@@ -46,14 +47,10 @@ func (y *YayClient) IsAvailable() error {
 
 // GetPackageInfo fetches PKGBUILD and metadata for a package
 func (y *YayClient) GetPackageInfo(ctx context.Context, packageName string) (*types.PackageInfo, error) {
-	// Get PKGBUILD content
-	cmd := exec.CommandContext(ctx, y.yayPath, "-G", "--print", packageName)
-	output, err := cmd.Output()
+	src, err := y.fetchPKGBUILD(ctx, packageName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get PKGBUILD for %s: %w", packageName, err)
+		return nil, err
 	}
-
-	src := string(output)
 
 	// Parse PKGBUILD for metadata. Name stays as the caller requested it: for a
 	// split package the requested name is the authoritative one, and it need not
@@ -80,6 +77,50 @@ func (y *YayClient) GetPackageInfo(ctx context.Context, packageName string) (*ty
 	info.Maintainer = vars.Maintainer()
 
 	return info, nil
+}
+
+// fetchPKGBUILD returns the PKGBUILD source yay holds for a package.
+//
+// yay resolves a binary repository ahead of the AUR, so for a package carried by
+// both -- an AUR package that some third-party repo also ships prebuilt -- the
+// default fetch asks Arch's packaging GitLab for a project that was never there.
+// GitLab answers that with a redirect to its sign-in page, and yay prints those
+// 19 KB of HTML as though they were the PKGBUILD. It exits 0 doing so, as it does
+// for every other failure on this path ("Unable to find the following packages"
+// is also a clean exit), which leaves the returned content as the only signal
+// worth reading. So: check what came back, and ask the AUR directly before
+// concluding there is nothing to analyze.
+func (y *YayClient) fetchPKGBUILD(ctx context.Context, packageName string) (string, error) {
+	src, err := y.printPKGBUILD(ctx, packageName)
+	if err == nil && pkgbuild.LooksLike(src) {
+		return src, nil
+	}
+
+	// --aur is the fallback rather than the default because it is the narrower
+	// question: it fails outright for the official packages the plain fetch
+	// serves correctly.
+	aurSrc, aurErr := y.printPKGBUILD(ctx, packageName, "--aur")
+	if aurErr == nil && pkgbuild.LooksLike(aurSrc) {
+		ui.Warn("%s: the repository source returned no PKGBUILD; analyzing the AUR PKGBUILD instead", packageName)
+		return aurSrc, nil
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("failed to get PKGBUILD for %s: %w", packageName, err)
+	}
+	// Refusing here is the point. The caller's next move is to hand this to an
+	// analyzer and report a verdict on it, and a verdict rendered over a sign-in
+	// page reads exactly like a verdict rendered over a clean package.
+	return "", fmt.Errorf("no PKGBUILD found for %s: yay returned %d bytes declaring no pkgname", packageName, len(strings.TrimSpace(src)))
+}
+
+// printPKGBUILD runs `yay -G --print` and returns its stdout verbatim.
+func (y *YayClient) printPKGBUILD(ctx context.Context, packageName string, extraArgs ...string) (string, error) {
+	args := append([]string{"-G", "--print"}, extraArgs...)
+	args = append(args, packageName)
+
+	output, err := exec.CommandContext(ctx, y.yayPath, args...).Output()
+	return string(output), err
 }
 
 // InstallPackages runs yay to install packages

--- a/internal/yay/yay_test.go
+++ b/internal/yay/yay_test.go
@@ -1,0 +1,170 @@
+package yay
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const realPKGBUILD = `# ya-claude-code
+
+# Maintainer: Aaron Bockelie <aaronsb@gmail.com>
+pkgname=ya-claude-code
+pkgver=2.1.233
+pkgrel=1
+pkgdesc="Claude Code CLI"
+url="https://github.com/anthropics/claude-code"
+depends=('bash' 'glibc')
+`
+
+// gitlabSignIn is the shape of what Arch's packaging GitLab returns for a
+// project that does not exist: a 302 to the sign-in page, which yay prints as
+// the PKGBUILD. Trimmed from the 19 KB the real fetch produced.
+const gitlabSignIn = `# ya-claude-code
+
+<!DOCTYPE html>
+<html class="html-devise-layout gl-system" lang="en">
+<head prefix="og: http://ogp.me/ns#">
+<title>Sign in · GitLab</title>
+<script>
+window.gon={};gon.gitlab_url="https://gitlab.archlinux.org";
+</script>
+</head>
+</html>
+`
+
+// fakeYay writes a stand-in yay that answers `-G --print` from repoOut and
+// `-G --print --aur` from aurOut, logging every invocation. An empty payload
+// means that call fails the way the real one does -- by exiting non-zero.
+func fakeYay(t *testing.T, repoOut, aurOut string) (yayPath, callLog string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	for name, content := range map[string]string{"repo.out": repoOut, "aur.out": aurOut} {
+		if content == "" {
+			continue // absent file: cat exits non-zero
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	script := "#!/bin/sh\n" +
+		"echo \"$*\" >> " + dir + "/calls.log\n" +
+		"for a in \"$@\"; do\n" +
+		"  [ \"$a\" = \"--aur\" ] && exec cat " + dir + "/aur.out\n" +
+		"done\n" +
+		"exec cat " + dir + "/repo.out\n"
+
+	yayPath = filepath.Join(dir, "yay")
+	if err := os.WriteFile(yayPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return yayPath, filepath.Join(dir, "calls.log")
+}
+
+func readLog(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// TestShadowedPackageFallsBackToAUR is the defect this fallback exists for.
+// ya-claude-code is in the AUR and in a third-party binary repository; yay
+// resolves the repository first, asks Arch's packaging GitLab for a project that
+// is not there, and prints the sign-in page it gets back -- exiting 0. That HTML
+// reached the analyzer as the PKGBUILD, and the resulting verdict described a
+// GitLab login form.
+func TestShadowedPackageFallsBackToAUR(t *testing.T) {
+	yayPath, callLog := fakeYay(t, gitlabSignIn, realPKGBUILD)
+	client := NewYayClient(yayPath)
+
+	info, err := client.GetPackageInfo(context.Background(), "ya-claude-code")
+	if err != nil {
+		t.Fatalf("GetPackageInfo: %v", err)
+	}
+
+	if strings.Contains(info.PKGBUILD, "DOCTYPE html") {
+		t.Error("PKGBUILD is the GitLab sign-in page; the fetch accepted HTML as package source")
+	}
+	if got, want := info.Version, "2.1.233"; got != want {
+		t.Errorf("Version = %q, want %q", got, want)
+	}
+	if got, want := info.Maintainer, "Aaron Bockelie <aaronsb@gmail.com>"; got != want {
+		t.Errorf("Maintainer = %q, want %q", got, want)
+	}
+	if !strings.Contains(readLog(t, callLog), "--aur") {
+		t.Error("never retried with --aur")
+	}
+}
+
+// TestOfficialPackageDoesNotAskAUR guards the cost of the fallback. `--aur` is
+// the narrower question -- it answers "Unable to find the following packages"
+// for anything in the official repositories -- so a plain fetch that already
+// produced a PKGBUILD must not be second-guessed.
+func TestOfficialPackageDoesNotAskAUR(t *testing.T) {
+	yayPath, callLog := fakeYay(t, "# bash\n\npkgname=bash\npkgver=5.3\n", "")
+	client := NewYayClient(yayPath)
+
+	info, err := client.GetPackageInfo(context.Background(), "bash")
+	if err != nil {
+		t.Fatalf("GetPackageInfo: %v", err)
+	}
+	if got, want := info.Version, "5.3"; got != want {
+		t.Errorf("Version = %q, want %q", got, want)
+	}
+	if strings.Contains(readLog(t, callLog), "--aur") {
+		t.Error("retried with --aur despite the first fetch returning a PKGBUILD")
+	}
+}
+
+// TestNoPKGBUILDAnywhereFails covers the case both sources miss. Returning the
+// content anyway is what produced a security verdict over a sign-in page, so the
+// only safe answer is to refuse.
+func TestNoPKGBUILDAnywhereFails(t *testing.T) {
+	yayPath, _ := fakeYay(t, gitlabSignIn, " -> Unable to find the following packages: nope\n")
+	client := NewYayClient(yayPath)
+
+	info, err := client.GetPackageInfo(context.Background(), "nope")
+	if err == nil {
+		t.Fatalf("GetPackageInfo succeeded, want error; PKGBUILD = %.60q", info.PKGBUILD)
+	}
+	if !strings.Contains(err.Error(), "no PKGBUILD found") {
+		t.Errorf("error = %v, want it to say no PKGBUILD was found", err)
+	}
+}
+
+// TestUnparseablePKGBUILDStillAnalyzed keeps the fetch check from becoming a
+// safety check. Bash that will not parse is a reason to look closer, not a
+// reason to drop the package -- so long as it is a PKGBUILD at all.
+func TestUnparseablePKGBUILDStillAnalyzed(t *testing.T) {
+	const broken = "# evil\n\npkgname=evil\ndepends=(unclosed\n"
+	yayPath, callLog := fakeYay(t, broken, "")
+	client := NewYayClient(yayPath)
+
+	info, err := client.GetPackageInfo(context.Background(), "evil")
+	if err != nil {
+		t.Fatalf("GetPackageInfo: %v", err)
+	}
+	if info.PKGBUILD != broken {
+		t.Errorf("PKGBUILD = %q, want the raw source passed through", info.PKGBUILD)
+	}
+	if strings.Contains(readLog(t, callLog), "--aur") {
+		t.Error("retried with --aur; unparseable is not the same as not-a-PKGBUILD")
+	}
+}
+
+// TestYayFailureIsReported covers yay itself exiting non-zero.
+func TestYayFailureIsReported(t *testing.T) {
+	yayPath, _ := fakeYay(t, "", "")
+	client := NewYayClient(yayPath)
+
+	if _, err := client.GetPackageInfo(context.Background(), "whatever"); err == nil {
+		t.Fatal("GetPackageInfo succeeded, want error")
+	}
+}


### PR DESCRIPTION
## The bug

`yay-friend analyze ya-claude-code` graded a GitLab login form and reported `MODERATE`.

`ya-claude-code` is in the AUR *and* in a third-party binary repo. yay resolves the repo first, so `yay -G --print` asks Arch's packaging GitLab for a project that was never there:

```
https://gitlab.archlinux.org/archlinux/packaging/packages/ya-claude-code/-/raw/main/PKGBUILD
→ 302 → sign-in page → 19,400 bytes of HTML
```

yay **exits 0**. So does `--aur` when it answers `Unable to find the following packages`. Every failure on this path is a clean exit, which is why nothing caught it — the content is the only signal available.

The provider noticed and said so in its own findings, which is how this surfaced:

> The file presented as the PKGBUILD is an HTML login page, not a shell script. No pkgname, pkgver, source array, sha256sums, build(), or package() function exists anywhere in the supplied content.

A user skimming for the verdict line sees `MODERATE` and no reason to read further.

## Three defects

**1. Fetch accepted anything yay printed.** Now `pkgbuild.LooksLike` asks the one question that separates a PKGBUILD from an error page — is `pkgname` or `pkgbase` declared — and a failure retries with `--aur` before giving up. `--aur` is the fallback, not the default: it fails outright for the official packages the plain fetch serves correctly, so packages that work today take no extra call.

The check is deliberately loose and deliberately not `Parse`. Source that declares a pkgname still reaches the analyzer even when the bash won't parse — unparseable bash is a reason to look closer, not a reason to drop the package. When neither source yields a PKGBUILD the fetch now fails loudly instead of forwarding garbage.

**2. AUR RPC metadata was fetched, then discarded.** `enrichFromAURData` read votes, popularity and dates and dropped the rest, so this response:

```json
{"Maintainer":"aaronsb","Version":"2.1.233-1","Description":"Claude Code CLI, verified at build time..."}
```

reached the provider as `Maintainer: Unknown, Version: (empty)` — and the provider marked the package down for exactly the risk the response in hand disproved. Now backfilled where the PKGBUILD is silent, with the PKGBUILD preferred where it spoke (its `pkgver` is the version being built; the RPC carries the pkgrel-qualified version last published). An orphaned package is named as orphaned, which its `# Maintainer:` comment cannot do — that comment still credits whoever left.

**3. Poisoned cache entries were permanent.** Entries key on the AUR commit hash, so a package whose PKGBUILD hasn't moved is never re-analyzed on its own — a verdict reached over a sign-in page would outlive the fix. `CacheVersion` was written but never read on the way back in; it's now load-bearing and bumped to `2.0`, so pre-fix entries read as misses and get re-analyzed. Existing caches are discarded once, which costs a round of AI calls.

## Verification

`internal/yay/yay_test.go` drives a stand-in yay through the real shapes — sign-in page, `Unable to find`, unparseable-but-real PKGBUILD, official package. Three of the tests fail against the current fetch path, with the sign-in page landing in `info.PKGBUILD` exactly as it did in production.

End-to-end on the package that surfaced this:

```
:: warning ya-claude-code: the repository source returned no PKGBUILD; analyzing the AUR PKGBUILD instead
  pkgbuild        115 lines of shell
  package         ya-claude-code 2.1.233
  maintainer      Aaron Bockelie <aaronsb@gmail.com>
  entropy         ▁ MINIMAL
  recommend       PROCEED
```

Full suite green, `go vet` clean, no new `gofmt` diffs.